### PR TITLE
Features/analytics documentation

### DIFF
--- a/models/analytics/intermediate/_intermediate.yml
+++ b/models/analytics/intermediate/_intermediate.yml
@@ -396,12 +396,136 @@ models:
         description: Timestamp that the data was loaded
 
   - name: f_boxscore_player
-    description: Staged boxscore player data from nhl-api (game-player level)
-
+    description: Final version of NHL boxscore player data from the NHL-API (game-player level). Each row represents an individual player's summarized activity in an NHL game
+    columns:
+      - name: id
+        description: Unique identifier for a player's summarized activity in an NHL game (game_id + team_id + player_id)
+        tests:
+          - unique
+          - not_null
+      - name: game_id
+        description: |
+          Foreign key that maps to an NHL game ID
+          {{ doc("game_id_description") }}
+      - name: team_id
+        description: Foreign key that maps to an NHL team ID
+      - name: player_id
+        description: Foreign key that maps to an NHL player ID
+      - name: team_name
+        description: Name of the NHL team
+      - name: team_type
+        description: Describes the Away / Home status for the team that the player belonged to in that game
+      - name: player_full_name
+        description: Full name of the NHL player
+      - name: player_roster_status
+        description: Roster status of the NHL player (e.g. Y, N, I)
+      - name: player_position_code
+        description: Position code (e.g. C, LW, D)
+      - name: time_on_ice
+        description: Time on ice in minutes:seconds (e.g. 21:30)
+      - name: assists
+        description: Number of assists (primary & secondary)
+      - name: goals
+        description: Number of goals scored
+      - name: shots
+        description: Number of shots taken
+      - name: hits
+        description: Number of hits made
+      - name: powerplay_goals
+        description: Number of powerplay goals scored
+      - name: powerplay_assists
+        description: Number of powerplay assists (primary & secondary)
+      - name: penalty_minutes
+        description: Number of penalties taken in minutes
+      - name: faceoff_wins
+        description: Number of faceoffs won
+      - name: faceoff_taken
+        description: Number of faceoffs taken
+      - name: takeaways
+        description: Number of takeaways made
+      - name: giveaways
+        description: Number of giveaways faulted for
+      - name: short_handed_goals
+        description: Number of short-handed goals scored
+      - name: short_handed_assists
+        description: Number of short-handed assists made
+      - name: blocked
+        description: Number of blocked shots
+      - name: plus_minus
+        description: Total plus minus in the game - plus for every goal scored while on the ice for, minus for every goal allowed while on the ice
+      - name: even_time_on_ice
+        description: Time on ice in minutes:seconds at event-strength (5v5)
+      - name: powerplay_time_on_ice
+        description: Time on ice in minutes:seconds on the man advantage / powerplay (5v4, 5v3, or 4v3)
+      - name: short_handed_time_on_ice
+        description: Time on ice in minutes:seconds while short-handed / on the penalty kill (4v5, 3v5, or 3v4)
+      - name: pim
+        description: Penalties in minutes:seconds
+      - name: saves
+        description: Number of saves made
+      - name: powerplay_saves
+        description: Number of saves made on the powerplay
+      - name: short_handed_saves
+        description: Number of saves made on the penalty kill / short-handed
+      - name: even_saves
+        description: Number of saves made at event strength
+      - name: short_handed_shots_against
+        description: Number of shots against on the penalth kill / short-handed
+      - name: even_shots_against
+        description:  Number of shots against at event strength
+      - name: powerplay_shots_against
+        description: Number of shots against on the powerplay / mad advantage
+      - name: decision
+        description: Win (W) or Loss (L) for goalies only (NULL if player)
+      - name: save_percentage
+        description: Percentage of shots faced that were saved (100% * (Number of shots saved / Number of shots))
+      - name: powerplay_save_percentage
+        description:  Percentage of shots faced on the powerplay that were saved (100% * (Number of shots saved / Number of shots))
+      - name: even_strength_save_percentage
+        description:  Percentage of shots faced at even strength that were saved (100% * (Number of shots saved / Number of shots))
 
   - name: f_boxscore_team
-    description: Staged boxscore player data from nhl-api (game-team level)
-
+    description: Final version of NHL boxscore game data from the NHL-API (game-team level)
+    columns:
+      - name: id
+        description: Unique identifier for an team's involvement in an NHL game (game_id + team_id)
+        tests:
+          - unique
+          - not_null
+      - name: game_id
+        description: |
+          Foreign key that maps to the NHL game ID - each game should have 2 rows in this table for each team involved in the game
+          {{ doc("game_id_description") }}
+      - name: team_id
+        description: Foreign key that maps to the NHL team ID - each row represents a team playing in a game
+      - name: team_type
+        description: Describes the Away / Home status for each team playing in a game
+      - name: team_name
+        description: Name of the NHL team
+      - name: team_winner
+        description: True of the team scored more than the opposing team, False if the team scored less than the opposing team, NULL for Shootout results (will be fixed by linescore data, boxscore does not tell us the result of a shootout)
+      - name: team_goals
+        description: Number of goals scored by the team
+      - name: team_goal_differential
+        description: The difference between the number of goals scored, and the number of goals allowed by the team
+      - name: team_pim
+        description:  The number of penalties in minutes:seconds against the team
+      - name: team_shots
+        description: The number of shots (unsure if this is on goal or attempts) for the team
+      - name: team_powerplay_goals
+        description: The number of powerplay goals for the team
+      - name: team_powerplay_opportunities
+        description: The number of powerplay opportunities for the team
+      - name: team_faceoff_percentage
+        description:  The percentage of faceoffs won by the team (e.g. 100 * (faceoff wins / faceoff attempts))
+      - name: team_blocked
+        description: The number of blocked shots for the team
+      - name: team_takeaways
+        description: The number of takeaways for the team
+      - name: team_giveaways
+        description: The number of giveaways for the team
+      - name: team_hits
+        description: The number of hits for the team
 
   - name: f_games
     description: Staged game data from nhl-api (game level)

--- a/models/analytics/intermediate/_intermediate.yml
+++ b/models/analytics/intermediate/_intermediate.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: d_conferences
-    description: Final version of NHL conferences data from nhl-api.
+    description: Final version of NHL conferences data from the NHL-API.
     columns:
       - name: id
         description: Unique identifier for NHL conferences
@@ -72,7 +72,7 @@ models:
 
 
   - name: d_draft
-    description: Final version of NHL rookie draft data from nhl-api (still to-do)
+    description: Final version of NHL rookie draft data from the NHL-API (still to-do)
     columns:
       - name: id
         description: Unique identifier for an NHL rookie draft (generated via dbt_utils.surrogate_key)
@@ -101,7 +101,7 @@ models:
         description: Name of the NHL team that drafted the NHL prospect
 
   - name: d_draft_prospects
-    description: Final version of NHL rookie draft prospects data from nhl-api (still to-do)
+    description: Final version of NHL rookie draft prospects data from the NHL-API (still to-do)
     columns:
       - name: id
         description: Unique identifier for a drafted NHL prospect
@@ -158,7 +158,7 @@ models:
         description: URL endpoint for the prospect
 
   - name: d_players
-    description: Final version of NHL player data from nhl-api (still to-do)
+    description: Final version of NHL player data from the NHL-API (still to-do)
     columns:
       - name: id
         description: Unique identifier for an NHL player
@@ -223,7 +223,7 @@ models:
         description: Timestamp that the data was loaded
 
   - name: d_schedule
-    description: Final version of NHL schedule data from nhl-api
+    description: Final version of NHL schedule data from the NHL-API
     columns:
       - name: id
         description: Unique identifier for NHL scheduled games
@@ -300,7 +300,7 @@ models:
         description: Timestamp that the data was loaded
 
   - name: d_seasons
-    description: Final version of NHL seasons data from nhl-api
+    description: Final version of NHL seasons data from the NHL-API
     columns:
       - name: id
         description: Unique identifier for an NHL season (e.g. "20172018")
@@ -331,7 +331,7 @@ models:
         description: Timestamp that the data was loaded
 
   - name: d_teams
-    description: Final version of NHL teams data from nhl-api
+    description: Final version of NHL teams data from the NHL-API
     columns:
       - name: id
         description: Unique identifier for NHL teams
@@ -528,8 +528,190 @@ models:
         description: The number of hits for the team
 
   - name: f_games
-    description: Staged game data from nhl-api (game level)
-
+    description: Final version of NHL boxscore & linescore data (game-level) from the NHL-API
+    columns:
+      - name: id
+        description: |
+          Unique identifier for an NHL game (game_id)
+          {{ doc("game_id_description") }}          tests:
+          - unique
+          - not_null
+      - name: game_id
+        description: |
+          Unique identifier for an NHL game (game_id)
+          {{ doc("game_id_description") }}        
+      - name: home_team_id
+        description: Foreign key that maps to an NHL team (home team)
+      - name: away_team_id
+        description: Foreign key that maps to an NHL team (away team)
+      - name: game_score_description
+        description: Description of the NHL game scoreline
+      - name: game_matchup_description
+        description: Description of the participants in the NHL game
+      - name: game_winning_team_id
+        description: Winning team's team ID
+      - name: game_winning_team_name
+        description: Winning team's team name
+      - name: game_absolute_goal_differential
+        description: Absolute goal differential between the winner and loser
+      - name: home_team_goals
+        description: Number of goals scored by the home team
+      - name: away_team_goals
+        description: Number of goals scored by the away team
+      - name: home_team_name
+        description: Home team's team name
+      - name: home_team_pim
+        description: Number of penalty minutes taken by the home team
+      - name: home_team_shots
+        description: Number of shots taken by the home team
+      - name: home_team_powerplay_goals
+        description: Number of powerplay goals scored by the home team
+      - name: home_team_powerplay_opportunities
+        description: Number of powerplay opportunities had by the home team
+      - name: home_team_faceoff_percentage
+        description: Faceoff percentage (wins / attempts) of the home team
+      - name: home_team_blocked
+        description: Number of blocked shots by the home team
+      - name: home_team_takeaways
+        description: Number of takeaways made by the home team
+      - name: home_team_giveaways
+        description: Number of giveaways faulted for by the home team
+      - name: home_team_hits
+        description: Number of hits made by the home team
+      - name: away_team_name
+        description: Away team's team name
+      - name: away_team_pim
+        description: Number of penalty minutes taken by the away team
+      - name: away_team_shots
+        description: Number of shots taken by the away team
+      - name: away_team_powerplay_goals
+        description: Number of powerplay goals scored by the away team
+      - name: away_team_powerplay_opportunities
+        description: Number of powerplay opportunities had by the away team
+      - name: away_team_faceoff_percentage
+        description: Faceoff percentage (wins / attempts) of the away team
+      - name: away_team_blocked
+        description: Number of blocked shots by the away team
+      - name: away_team_takeaways
+        description: Number of takeaways made by the away team
+      - name: away_team_giveaways
+        description: Number of giveaways faulted for by the away team
+      - name: away_team_hits
+        description: Number of hits made by the away team
 
   - name: f_plays
-    description: Staged play-by-play data from nhl-api (player-play level)
+    description: Final version of NHL event level data from the NHL-API (player-play level)
+    columns:
+      - name: id
+        description: Unique identifier for a player's event-level activity in an NHL game (game_id + team_id + player_id + event_id)
+        tests:
+          - unique
+          - not_null
+      - name: game_id
+        description: |
+          Foreign key that maps to an NHL game ID
+          {{ doc("game_id_description") }}
+      - name: event_idx
+        description: Foreign key that maps to the sequence of the event relative to that game, in ascending order (e.g. 1 = first event, 2 - second event)
+      - name: event_id
+        description: Foreign key that maps to a distinct event ID
+      - name: player_id
+        description: Foreign key that maps to an NHL player ID
+      - name: team_id
+        description: Foreign key that maps to an NHL team ID
+      - name: player_role
+        description: The role of the player in context to the event (e.g. Hitter, Hitee, Shooter, Winner, Loser, etc.)
+      - name: player_role_team
+        description: The home / away status of the player's team
+      - name: event_type
+        description: Short description of the event type
+      - name: event_code
+        description: Event code that is unique at the game-event level (e.g. PHI8, PHI10)
+      - name: event_description
+        description: Long description of the event (repeated for all the player's involved in the event)
+      - name: play_x_coordinate
+        description: The x-coordinate of where the event took place on the ice
+      - name: play_y_coordinate
+        description: The y-coordinate of where the event took place on the ice
+      - name: play_period
+        description: The period in which the event occured (e.g. 3)
+      - name: play_period_type
+        description: The type of period in which the event occured (e.g. Regular)
+      - name: play_period_time_elapsed
+        description: The time in minutes elapsed in the period
+      - name: play_period_time_remaining
+        description: The time in minutes remaining in the period
+      - name: play_period_seconds_elapsed
+        description: The time in seconds elapsed in the period
+      - name: play_period_seconds_remaining
+        description: The time in seconds remaining the period
+      - name: play_total_seconds_elapsed
+        description: The time in seconds elapsed in the entire game
+      - name: play_total_seconds_remaining
+        description: The time in seconds remaining in the entire game
+      - name: play_time
+        description: A timestamp of the event (e.g. 2021-01-13T22:32:45Z)
+      - name: shots_away
+        description: Cumulative away team shots taken in the game at the point in time where the event occured
+      - name: shots_home
+        description:  Cumulative ome team shots taken in the game at the point in time where the event occured
+      - name: hits_away
+        description:  Cumulative away team hits made in the game at the point in time where the event occured
+      - name: hits_home
+        description:  Cumulative home team hits made in the game at the point in time where the event occured
+      - name: faceoffs_away
+        description:  Cumulative away team faceoffs won in the game at the point in time where the event occured
+      - name: faceoffs_home
+        description:  Cumulative home team faceoffs won in the game at the point in time where the event occured
+      - name: takeaways_away
+        description: Cumulative away team takeaways forced in the game at the point in time where the event occured
+      - name: takeaways_home
+        description: Cumulative home team takeaways forced in the game at the point in time where the event occured
+      - name: giveaways_away
+        description: Cumulative away team giveaways made in the game at the point in time where the event occured
+      - name: giveaways_home
+        description: Cumulative home team giveaways made in the game at the point in time where the event occured
+      - name: missedshots_away
+        description: Cumulative away team missed shots taken in the game at the point in time where the event occured
+      - name: missedshots_home
+        description: Cumulative home team missed shots taken in the game at the point in time where the event occured
+      - name: blockedshots_away
+        description: Cumulative away team blocked shots made in the game at the point in time where the event occured
+      - name: blockedshots_home
+        description: Cumulative home team blocked shots made in the game at the point in time where the event occured
+      - name: penalties_away
+        description: Cumulative away team penalties in minutes taken in the game at the point in time where the event occured
+      - name: penalties_home
+        description: Cumulative home team penalties in minutes taken in the game at the point in time where the event occured
+      - name: first_goal_scored
+        description: Whether or not the event in question was the first goal of the game (1 or 0)
+      - name: last_goal_scored
+        description: Whether or not the event in question was the last goal of the game (1 or 0)
+      - name: goals_away
+        description: Cumulative away team goals scored in the game at the point in time where the event occured
+      - name: goals_home
+        description: Cumulative home team goals scored in the game at the point in time where the event occured
+      - name: goal_difference_current
+        description: The absolute value difference in goals between the home and away teams in the game at the point in time where the event occured
+      - name: winning_team_current
+        description: The name of the team_type (e.g. "Tie", "Home" or "Away") for the team currently winning
+      - name: game_state_current
+        description: The current state of scoreboard (e.g. "Tie", "Close" (1 goal difference), "Buffer" (2 goal difference), "Comfortable" (3 goal difference), "Blowout" (4 goal difference))
+      - name: home_result_of_play
+        description: Description of the result of the current event / play for the home team (e.g. "No change", "Chase goal", "Tying goal scored", "Tying goal allowed", "Go-ahead goal scored, Buffer goal", "Go-ahead goal allowed")
+      - name: away_result_of_play
+        description: Description of the result of the current event / play for the away team (e.g. "No change", "Chase goal", "Tying goal scored", "Tying goal allowed", "Go-ahead goal scored, Buffer goal", "Go-ahead goal allowed")
+      - name: last_goal_game_winning
+        description: Whether or not the the current goal was the last goal and also the game winning goal (1 or 0)
+      - name: last_goal_game_tying
+        description: Whether or not the the current goal was the last goal and also the game tying goal (1 or 0)
+      - name: goals_home_lag
+        description: Cumulative home team goals scored in the game 1 play before the current play (e.g. if event prior to this event was a home team goal, and the current play was a hit, then the value for this column would be 1)
+      - name: goals_away_lag
+        description: Cumulative away team goals scored in the game 1 play before the current play (e.g. if event prior to this event was a away team goal, and the current play was a hit, then the value for this column would be 1)
+      - name: goal_difference_lag
+        description: The absolute value difference in goals between the home and away teams in the game using the home and away team lagged goals scored
+      - name: winning_team_lag
+        description: Determines the previously winning team (e.g. "Tie", "Home" or "Away") before the play in question
+      - name: game_state_lag
+        description: The previous state of scoreboard prior to the play in question (e.g. "Tie", "Close" (1 goal difference), "Buffer" (2 goal difference), "Comfortable" (3 goal difference), "Blowout" (4 goal difference))

--- a/models/analytics/intermediate/_intermediate.yml
+++ b/models/analytics/intermediate/_intermediate.yml
@@ -20,6 +20,35 @@ models:
       - name: is_active
         description: Whether or not the conference is still active
 
+  - name: d_date
+    description: Final version of calendar days data (2010-01-01 - 2030-01-01)
+    columns:
+      - name: id
+        description: Unique identifier for a calendar day (formatted from date_day as '%Y%m%d')
+        tests:
+          - unique
+          - not_null
+      - name: date_day
+        description: Day expressed as YYYY-MM-DD
+      - name: day_of_week_name
+        description: Calendar day of week name (e.g. Monday)
+      - name: year_number
+        description: Year number (e.g. 2022)
+      - name: quarter_number
+        description: Quarter number (e.g. 1, 2, 3, 4)
+      - name: quarter_desc
+        description: Description of the quarter + year, with "Q" as the prefix
+      - name: month_number
+        description: Month number (e.g. 1, 2, 3, 4... 12)
+      - name: month_name
+        description: Name of the month (e.g. January)
+      - name: month_desc
+        description: Description of the month + year, with "M" as the prefix
+      - name: week_number
+        description: Week number relative to year
+      - name: week_desc
+        description: Description of the week + year, with "Wk" as the prefix
+
   - name: d_divisions
     description: Final version of NHL division data from the NHL-API
     columns:
@@ -193,7 +222,6 @@ models:
       - name: loaded_at
         description: Timestamp that the data was loaded
 
-
   - name: d_schedule
     description: Final version of NHL schedule data from nhl-api
     columns:
@@ -272,12 +300,100 @@ models:
         description: Timestamp that the data was loaded
 
   - name: d_seasons
-    description: Staged seasons data from nhl-api
-
+    description: Final version of NHL seasons data from nhl-api
+    columns:
+      - name: id
+        description: Unique identifier for an NHL season (e.g. "20172018")
+        tests:
+          - unique
+          - not_null
+      - name: regular_season_start_date
+        description: The first date of the NHL regular season (e.g. "2017-10-04")
+      - name: regular_season_end_date
+        description: The last date of the NHL regular season (e.g. "2018-04-08")
+      - name: season_end_date
+        description: The last date of the NHL post season (e.g. "2018-06-07")
+      - name: number_of_games
+        description: The number of total games played by each NHL team
+      - name: has_ties_in_use
+        description: Whether or not ties were possible for that season (True / False)
+      - name: has_olympics_participation
+        description: Whether or not olympic participation at the NHL level was allowed for that season (True / False)
+      - name: has_conferences_in_use
+        description: Whether or not conferences were used for that season's playoff consideration (True / False)
+      - name: has_divisions_in_use
+        description: Whether or not divisions were used for that season's playoff consideration (True / False)
+      - name: has_wildcard_in_use
+        description: Whether or not wildcards were used for that season's playoff consideration (True / False)
+      - name: extracted_at
+        description: Timestamp that the data was retrieved
+      - name: loaded_at
+        description: Timestamp that the data was loaded
 
   - name: d_teams
-    description: Staged teams data from nhl-api
-
+    description: Final version of NHL teams data from nhl-api
+    columns:
+      - name: id
+        description: Unique identifier for NHL teams
+        tests:
+          - unique
+          - not_null
+      - name: venue_timezone_id
+        description: Foreign key that maps to the timezone ID of the venue (e.g. America/Vancouver)
+      - name: division_id
+        description: Foreign key that maps to the division ID that the NHL team belongs to
+      - name: conference_id
+        description: Foreign key that maps to the conference ID that the NHL team belongs to
+      - name: franchise_id
+        description: Foreign key that maps to the franchise ID that the NHL originates from
+      - name: full_name
+        description: Full name of the NHL team (e.g. Vancouver Canucks)
+      - name: team_url
+        description: URL endpoint for the NHl team
+      - name: venue_name
+        description: Name of the venue / arena that the NHL team plays in
+      - name: venue_url
+        description: URL endpoint for the NHL team venue
+      - name: venue_city
+        description: City that the venue / arena is in
+      - name: venue_timezone_offset
+        description: Offset necessary to correct for timezone differences (e.g. Vancouver = -7)
+      - name: venue_timezone_name
+        description: Abbreviated timezone for the venue (e.g. PDT)
+      - name: abbreviation
+        description: Abbreviation for the NHL team (e.g. VAN)
+      - name: team_name
+        description: Second part of the team name (e.g. Canucks)
+      - name: location_name
+        description: First part of the team name (e.g. Vancouer)
+      - name: first_year_of_play
+        description: The inaugural year for the NHL team (e.g. 1970)
+      - name: division_name
+        description: Name of the division that the team currently plays in
+      - name: division_short_name
+        description: Short name for the division that the team currently plays in
+      - name: division_url
+        description: URL endpoint for division
+      - name: division_abbreviation
+        description: Abbreviated NHL division name (e.g. P)
+      - name: conference_name
+        description: Conference name that the team currently plays in
+      - name: conference_url
+        description: URL endpoint for the conference
+      - name: franchise_team_name
+        description: Name of the franchise (second part of full team name)
+      - name: franchise_url
+        description: URL endpoint for the franchise
+      - name: short_name
+        description: Slightly different short version of the team name
+      - name: official_site_url
+        description: Official site URL
+      - name: is_active
+        description: Whether or not the team is currently active in the NHL
+      - name: extracted_at
+        description: Timestamp that the data was retrieved
+      - name: loaded_at
+        description: Timestamp that the data was loaded
 
   - name: f_boxscore_player
     description: Staged boxscore player data from nhl-api (game-player level)

--- a/models/analytics/intermediate/_intermediate.yml
+++ b/models/analytics/intermediate/_intermediate.yml
@@ -2,26 +2,81 @@ version: 2
 
 models:
   - name: d_conferences
-    description: Staged conferences data from nhl-api.
+    description: Final version of NHL conferences data from nhl-api.
+    columns:
+   - name: id
+          description: Unique identifier for NHL conferences
+          tests:
+            - unique
+            - not_null
+        - name: conference_name
+          description: Name of the NHL conference
+        - name: conference_url
+          description: URL endpoint
+        - name: conference_abbreviation
+          description: Abbreviated NHL conference name
+        - name: conference_short_name
+          description: Short name for the NHL conference
+        - name: is_active
+          description: Whether or not the conference is still active
+
   - name: d_divisions
-    description: Staged division data from nhl-api.
+    description: Final version of NHL division data from the NHL-API
+    columns:
+      - name: id
+        description: Unique identifier for NHL divisions
+        tests:
+          - unique
+          - not_null
+      - name: conference_id
+        description: Foreign key that maps to the NHL conference ID
+      - name: division_name
+        description: Name of the NHL division
+      - name: division_short_name
+        description: Short name for the NHL division
+      - name: division_url
+        description: URL endpoint
+      - name: division_abbreviation
+        description: Abbreviated NHL conference name
+      - name: is_active
+        description: Whether or not the conference is still active
+
+
   - name: d_draft
     description: Staged draft data from nhl-api (still to-do)
+
+
   - name: d_draft_prospects
     description: Staged draft_prospects data from nhl-api (still to-do)
+
+
   - name: d_players
     description: Staged player data from nhl-api
+
+
   - name: d_schedule
     description: Staged schedule data from nhl-api
+
+
   - name: d_seasons
     description: Staged seasons data from nhl-api
+
+
   - name: d_teams
     description: Staged teams data from nhl-api
+
+
   - name: f_boxscore_player
     description: Staged boxscore player data from nhl-api (game-player level)
+
+
   - name: f_boxscore_team
     description: Staged boxscore player data from nhl-api (game-team level)
+
+
   - name: f_games
     description: Staged game data from nhl-api (game level)
+
+
   - name: f_plays
     description: Staged play-by-play data from nhl-api (player-play level)

--- a/models/analytics/intermediate/_intermediate.yml
+++ b/models/analytics/intermediate/_intermediate.yml
@@ -4,21 +4,21 @@ models:
   - name: d_conferences
     description: Final version of NHL conferences data from nhl-api.
     columns:
-   - name: id
-          description: Unique identifier for NHL conferences
-          tests:
-            - unique
-            - not_null
-        - name: conference_name
-          description: Name of the NHL conference
-        - name: conference_url
-          description: URL endpoint
-        - name: conference_abbreviation
-          description: Abbreviated NHL conference name
-        - name: conference_short_name
-          description: Short name for the NHL conference
-        - name: is_active
-          description: Whether or not the conference is still active
+      - name: id
+        description: Unique identifier for NHL conferences
+        tests:
+          - unique
+          - not_null
+      - name: conference_name
+        description: Name of the NHL conference
+      - name: conference_url
+        description: URL endpoint
+      - name: conference_abbreviation
+        description: Abbreviated NHL conference name
+      - name: conference_short_name
+        description: Short name for the NHL conference
+      - name: is_active
+        description: Whether or not the conference is still active
 
   - name: d_divisions
     description: Final version of NHL division data from the NHL-API
@@ -43,20 +43,233 @@ models:
 
 
   - name: d_draft
-    description: Staged draft data from nhl-api (still to-do)
-
+    description: Final version of NHL rookie draft data from nhl-api (still to-do)
+    columns:
+      - name: id
+        description: Unique identifier for an NHL rookie draft (generated via dbt_utils.surrogate_key)
+        tests:
+          - unique
+          - not_null
+      - name: overall_pick_id
+        description: Unique identifier for an NHL rookie draft (draft year + overall pick)
+      - name: draft_prospect_id
+        description: Foreign key that maps to an NHL draft prospect
+      - name: draft_team_id
+        description: Foreign key that maps to the NHL team that drafted the NHL prospect
+      - name: draft_year
+        description: Year of the NHL entry draft
+      - name: draft_overall_pick
+        description: The overall pick in the NHL entry draft. For example, `1` is the first overall pick
+      - name: draft_round
+        description: The drafting round that the selection was made in
+      - name: draft_round_pick
+        description: The pick in the NHL entry draft made relative to the round
+      - name: draft_prospect_name
+        description: Name of the drafted NHL prospect
+      - name: draft_url
+        description: URL endpoint
+      - name: draft_team_name
+        description: Name of the NHL team that drafted the NHL prospect
 
   - name: d_draft_prospects
-    description: Staged draft_prospects data from nhl-api (still to-do)
-
+    description: Final version of NHL rookie draft prospects data from nhl-api (still to-do)
+    columns:
+      - name: id
+        description: Unique identifier for a drafted NHL prospect
+        tests:
+          - unique
+          - not_null
+      - name: prospect_player_id
+        description: Foreign key that maps to an NHL player ID
+      - name: prospect_category_id
+        description: Foreign key that maps to one of the four prospect categories - North American Skater (1), European Skater (2), North American Goalie (3) or European Goalie (4)
+      - name: prospect_first_name
+        description: First name of the NHL prospect
+      - name: prospect_last_name
+        description: Last name of the NHL prospect
+      - name: prospect_full_name
+        description: Full name of the NHL prospect
+      - name: prospect_birth_date
+        description: Birth date of the NHL prospect
+      - name: prospect_age_years
+        description: Age in years of the NHL prospect
+      - name: prospect_age_days
+        description: Age in days of the NHL prospect
+      - name: prospect_birth_city
+        description: Birth city of the NHL prospect
+      - name: prospect_birth_state_province
+        description: Birth state or province of the NHL prospect
+      - name: prospect_birth_country
+        description: Birth country of the NHL prospect
+      - name: prospect_height
+        description: Imperial height, in feet and inches (e.g. 5'10")
+      - name: prospect_weight
+        description: Imperial weight, in pounds (e.g. 140)
+      - name: prospect_shoots_catches
+        description: The handedness of the NHL prospect (e.g. R = right, L = left)
+      - name: prospect_position_name
+        description: Name of the position (e.g. Center, Left Wing, Defenseman)
+      - name: prospect_position_abbreviation
+        description: Abbreviation of the position (e.g. C, LW, D)
+      - name: prospect_draft_status
+        description: Unknown (e.g. NHL-10, NHL-54)
+      - name: prospect_category_name
+        description: Describes four prospect categories - North American Skater, European Skater, North American Goalie or European Goalie
+      - name: prospect_category_short_name
+        description: Describes four prospect categories - NA Skater, Euro Skater, NA Goalie or Euro Goalie
+      - name: prospect_amateur_team_name
+        description: Name of the amateur team that the NHL prospect plays for - unknown when, lots of nulls
+      - name: prospect_amateur_team_url
+        description: URL endpoint for amateur team
+      - name: prospect_rank_midterm
+        description: Unknown, lots of nulls
+      - name: prospect_rank_draft_year
+        description: Unknown, lots of null
+      - name: prospect_url
+        description: URL endpoint for the prospect
 
   - name: d_players
-    description: Staged player data from nhl-api
+    description: Final version of NHL player data from nhl-api (still to-do)
+    columns:
+      - name: id
+        description: Unique identifier for an NHL player
+        tests:
+          - unique
+          - not_null
+      - name: current_team_id
+        description: Foreign key that maps to the NHL team ID that the NHL player currently plays for
+      - name: full_name
+        description: Full name of the NHL player
+      - name: player_url
+        description: URL endpoint for NHL player
+      - name: first_name
+        description: First name of the NHL player
+      - name: last_name
+        description: Last name of the NHL player
+      - name: primary_number
+        description: Number that the player usually wears
+      - name: birth_date
+        description: Birth date of the NHL player
+      - name: current_age
+        description: Age in years of the NHL player
+      - name: birth_city
+        description: Birth city of the NHL player
+      - name: birth_state_province
+        description: Birth state or province of the NHL player
+      - name: birth_country
+        description: Birth country of the NHL player
+      - name: nationality
+        description: Nationality of the NHL player
+      - name: height
+        description: Imperial height, in feet and inches (e.g. 5'10")
+      - name: weight
+        description: Imperial weight, in pounds (e.g. 140)
+      - name: is_active
+        description: Whether or not the NHL player is currently active (True / False)
+      - name: is_alternate_captain
+        description: Whether or not the NHL player is currently an alternate captain for their team (True / False)
+      - name: is_captain
+        description: Whether or not the NHL player is currently the captain of their team (True / False)
+      - name: is_rookie
+        description: Whether or not the NHL player is currently a rookie (True / False)
+      - name: shoots_catches
+        description: The handedness of the NHL player (e.g. R = right, L = left)
+      - name: roster_status
+        description: Roster status of the NHL player (e.g. Y, N, I)
+      - name: current_team_name
+        description: Name of the NHL team the player currently plays for
+      - name: current_team_url
+        description: URL endpoint for current NHL team
+      - name: primary_position_code
+        description: Position code of the position most played (e.g. C, L, D)
+      - name: primary_position_name
+        description: Position name of the position most played (e.g. Center, Left Wing, Defenseman)
+      - name: primary_position_type
+        description: Position grouping for the position most played (e.g. Forward, Defenseman)
+      - name: primary_position_abbreviation
+        description: Position abbreviation of the position most played (e.g. C, LW, D)
+      - name: extracted_at
+        description: Timestamp that the data was retrieved
+      - name: loaded_at
+        description: Timestamp that the data was loaded
 
 
   - name: d_schedule
-    description: Staged schedule data from nhl-api
-
+    description: Final version of NHL schedule data from nhl-api
+    columns:
+      - name: id
+        description: Unique identifier for NHL scheduled games
+        tests:
+          - unique
+          - not_null
+      - name: game_id
+        description: |
+          Foreign key that maps to an NHL game
+          {{ doc("game_id_description") }}
+      - name: season_id
+        description: Foreign key that maps to an NHL season
+      - name: away_team_id
+        description: Foreign key that maps to an NHL team (away team)
+      - name: home_team_id
+        description: Foreign key that maps to an NHL team (home team)
+      - name: venue_id
+        description: Foreign key tha tmaps to a team's venu (home team)
+      - name: game_number
+        description: Four digit number that is unique to a game in the context of a season (e.g. 0002)
+      - name: url
+        description: URL endpoint for schedule
+      - name: game_type
+        description: Code for the type of game (e.g. R = regular season)
+      - name: game_date
+        description: Date that the game takes place (e.g. 2021-01-14)
+      - name: abstract_game_state
+        description: Game state (e.g. Final)
+      - name: coded_game_state
+        description: Coded game state (e.g. 7)
+      - name: detailed_state
+        description: Detailed game state (e.g. Final) - should be different that game state, but look similar
+      - name: status_code
+        description: Unknown - looks similar to code_game_state
+      - name: is_start_time_tbd
+        description: Whether or not the start time is still to be decided (True / False)
+      - name: away_team_wins
+        description: Cumulative number of wins for the away team for the given season (wins for the team at that point in time)
+      - name: away_team_losses
+        description: Cumulative number of losses for the away team for the given season (losses for the team at that point in time)
+      - name: away_team_ot
+        description: Cumulative number of overtime wins for the away team for the given season (overtime wins for the team at that point in time)
+      - name: away_team_type
+        description: Type of away team (e.g. League)
+      - name: away_team_score
+        description: Goals scored by the away team
+      - name: away_team_name
+        description: Away team name
+      - name: away_team_url
+        description: Away team URL endpoint
+      - name: home_team_wins
+        description: Cumulative number of wins for the home team for the given season (wins for the team at that point in time)
+      - name: home_team_losses
+        description: Cumulative number of losses for the home team for the given season (losses for the team at that point in time)
+      - name: home_team_ot
+        description: Cumulative number of overtime wins for the home team for the given season (overtime wins for the team at that point in time)
+      - name: home_team_type
+        description: Type of home team (e.g. League)
+      - name: home_team_score
+        description: Goals scored by the home team
+      - name: home_team_name
+        description: Home team name
+      - name: home_team_url
+        description: Home team URL endpoint
+      - name: venue_name
+        description: Home team's venue / arena that the teams played in
+      - name: venue_url
+        description: URL endpoint for the venue
+      - name: content_url
+        description: URL endpoint for the content
+      - name: extracted_at
+        description: Timestamp that the data was retrieved
+      - name: loaded_at
+        description: Timestamp that the data was loaded
 
   - name: d_seasons
     description: Staged seasons data from nhl-api

--- a/models/analytics/intermediate/d_divisions.sql
+++ b/models/analytics/intermediate/d_divisions.sql
@@ -1,15 +1,14 @@
 select
     /* Primary Key */
-    id
-
+    stg_meltano__divisions.id
     /* Foreign Keys */
-    , conference_id
-
+    ,stg_meltano__divisions.conference_id
     /* Properties */
-    , division_name
-    , division_name_short as division_short_name
-    , division_url
-    , division_abbreviation
-    , is_active
+    ,stg_meltano__divisions.division_name
+    ,stg_meltano__divisions.division_short_name 
+    ,stg_meltano__divisions.division_url
+    ,stg_meltano__divisions.division_abbreviation
+    ,stg_meltano__divisions.is_active
 
-from {{ ref('stg_meltano__divisions') }}
+from 
+    {{ ref('stg_meltano__divisions') }}

--- a/models/analytics/intermediate/d_divisions.sql
+++ b/models/analytics/intermediate/d_divisions.sql
@@ -7,7 +7,7 @@ select
 
     /* Properties */
     , division_name
-    , division_name_short
+    , division_name_short as division_short_name
     , division_url
     , division_abbreviation
     , is_active

--- a/models/analytics/intermediate/d_schedule.sql
+++ b/models/analytics/intermediate/d_schedule.sql
@@ -1,40 +1,42 @@
 select
     /* Primary Key */
-    game_id
+    stg_meltano__schedule.id
 
     /* Foreign Keys */
-    , season_id
-    , away_team_id
-    , home_team_id
-    , venue_id
+    ,stg_meltano__schedule.game_id
+    ,stg_meltano__schedule.season_id
+    ,stg_meltano__schedule.away_team_id
+    ,stg_meltano__schedule.home_team_id
+    ,stg_meltano__schedule.venue_id
 
     /* Properties */
-    , game_number
-    , url
-    , game_type
-    , game_date
-    , abstract_game_state
-    , coded_game_state
-    , detailed_state
-    , status_code
-    , is_start_time_tbd
-    , away_team_wins
-    , away_team_losses
-    , away_team_ot
-    , away_team_type
-    , away_team_score
-    , away_team_name
-    , away_team_url
-    , home_team_wins
-    , home_team_losses
-    , home_team_ot
-    , home_team_type
-    , home_team_score
-    , home_team_name
-    , home_team_url
-    , venue_name
-    , venue_url
-    , content_url
-    , extracted_at
-    , loaded_at
+    ,stg_meltano__schedule.game_number
+    ,stg_meltano__schedule.url
+    ,stg_meltano__schedule.game_type
+    ,stg_meltano__schedule.game_date
+    ,stg_meltano__schedule.abstract_game_state
+    ,stg_meltano__schedule.coded_game_state
+    ,stg_meltano__schedule.detailed_state
+    ,stg_meltano__schedule.status_code
+    ,stg_meltano__schedule.is_start_time_tbd
+    ,stg_meltano__schedule.away_team_wins
+    ,stg_meltano__schedule.away_team_losses
+    ,stg_meltano__schedule.away_team_ot
+    ,stg_meltano__schedule.away_team_type
+    ,stg_meltano__schedule.away_team_score
+    ,stg_meltano__schedule.away_team_name
+    ,stg_meltano__schedule.away_team_url
+    ,stg_meltano__schedule.home_team_wins
+    ,stg_meltano__schedule.home_team_losses
+    ,stg_meltano__schedule.home_team_ot
+    ,stg_meltano__schedule.home_team_type
+    ,stg_meltano__schedule.home_team_score
+    ,stg_meltano__schedule.home_team_name
+    ,stg_meltano__schedule.home_team_url
+    ,stg_meltano__schedule.venue_name
+    ,stg_meltano__schedule.venue_url
+    ,stg_meltano__schedule.content_url
+    ,stg_meltano__schedule.extracted_at
+    ,stg_meltano__schedule.loaded_at
+
 from {{ ref('stg_meltano__schedule') }}

--- a/models/staging/_staging.yml
+++ b/models/staging/_staging.yml
@@ -127,7 +127,7 @@ models:
         - name: prospect_url
           description: URL endpoint for the prospect
 
-    - name: stg_meltano__boxscore_game
+    - name: stg_meltano__boxscore
       description: Staged NHL boxscore data from the NHL-API (will be replaced/enhanced by linescore)
       columns:
         - name: id
@@ -137,6 +137,89 @@ models:
           tests:
             - unique
             - not_null
+
+    - name: stg_meltano__linescore
+      description: Staged NHL linescore data from the NHL-API (enhancement on stg_meltano__boxscore)
+      columns:
+        - name: id
+          description: |
+            Unique identifier for an NHL game (game_id)
+            {{ doc("game_id_description") }}
+          tests:
+            - unique
+            - not_null
+
+   - name: stg_meltano__games
+      description: Staged NHL boxscore & linescore data from the NHL-API
+      columns:
+        - name: id
+          description: |
+            Unique identifier for an NHL game (game_id)
+            {{ doc("game_id_description") }}          tests:
+            - unique
+            - not_null
+        - name: game_id
+          description: |
+            Unique identifier for an NHL game (game_id)
+            {{ doc("game_id_description") }}        
+        - name: home_team_id
+          description: Foreign key that maps to an NHL team (home team)
+        - name: away_team_id
+          description: Foreign key that maps to an NHL team (away team)
+        - name: game_score_description
+          description: Description of the NHL game scoreline
+        - name: game_matchup_description
+          description: Description of the participants in the NHL game
+        - name: game_winning_team_id
+          description: Winning team's team ID
+        - name: game_winning_team_name
+          description: Winning team's team name
+        - name: game_absolute_goal_differential
+          description: Absolute goal differential between the winner and loser
+        - name: home_team_goals
+          description: Number of goals scored by the home team
+        - name: away_team_goals
+          description: Number of goals scored by the away team
+        - name: home_team_name
+          description: Home team's team name
+        - name: home_team_pim
+          description: Number of penalty minutes taken by the home team
+        - name: home_team_shots
+          description: Number of shots taken by the home team
+        - name: home_team_powerplay_goals
+          description: Number of powerplay goals scored by the home team
+        - name: home_team_powerplay_opportunities
+          description: Number of powerplay opportunities had by the home team
+        - name: home_team_faceoff_percentage
+          description: Faceoff percentage (wins / attempts) of the home team
+        - name: home_team_blocked
+          description: Number of blocked shots by the home team
+        - name: home_team_takeaways
+          description: Number of takeaways made by the home team
+        - name: home_team_giveaways
+          description: Number of giveaways faulted for by the home team
+        - name: home_team_hits
+          description: Number of hits made by the home team
+        - name: away_team_name
+          description: Away team's team name
+        - name: away_team_pim
+          description: Number of penalty minutes taken by the away team
+        - name: away_team_shots
+          description: Number of shots taken by the away team
+        - name: away_team_powerplay_goals
+          description: Number of powerplay goals scored by the away team
+        - name: away_team_powerplay_opportunities
+          description: Number of powerplay opportunities had by the away team
+        - name: away_team_faceoff_percentage
+          description: Faceoff percentage (wins / attempts) of the away team
+        - name: away_team_blocked
+          description: Number of blocked shots by the away team
+        - name: away_team_takeaways
+          description: Number of takeaways made by the away team
+        - name: away_team_giveaways
+          description: Number of giveaways faulted for by the away team
+        - name: away_team_hits
+          description: Number of hits made by the away team
 
     - name: stg_meltano__boxscore_team
       description: Staged NHL boxscore game data from the NHL-API (game-team level)

--- a/models/staging/_staging.yml
+++ b/models/staging/_staging.yml
@@ -32,7 +32,7 @@ models:
           description: Foreign key that maps to the NHL conference
         - name: division_name
           description: Name of the NHL division
-        - name: division_name_short
+        - name: division_short_name
           description: Short name for the NHL division
         - name: division_url
           description: URL endpoint

--- a/models/staging/_staging.yml
+++ b/models/staging/_staging.yml
@@ -1,710 +1,710 @@
 version: 2
 
 models:
-    - name: stg_meltano__conferences
-      description: Staged NHL conferences data from the NHL-API
-      columns:
-        - name: id
-          description: Unique identifier for NHL conferences
-          tests:
-            - unique
-            - not_null
-        - name: conference_name
-          description: Name of the NHL conference
-        - name: conference_url
-          description: URL endpoint
-        - name: conference_abbreviation
-          description: Abbreviated NHL conference name
-        - name: conference_short_name
-          description: Short name for the NHL conference
-        - name: is_active
-          description: Whether or not the conference is still active
+  - name: stg_meltano__conferences
+    description: Staged NHL conferences data from the NHL-API
+    columns:
+      - name: id
+        description: Unique identifier for NHL conferences
+        tests:
+          - unique
+          - not_null
+      - name: conference_name
+        description: Name of the NHL conference
+      - name: conference_url
+        description: URL endpoint
+      - name: conference_abbreviation
+        description: Abbreviated NHL conference name
+      - name: conference_short_name
+        description: Short name for the NHL conference
+      - name: is_active
+        description: Whether or not the conference is still active
 
-    - name: stg_meltano__divisions
-      description: Staged NHL division data from the NHL-API
-      columns:
-        - name: id
-          description: Unique identifier for NHL divisions
-          tests:
-            - unique
-            - not_null
-        - name: conference_id
-          description: Foreign key that maps to the NHL conference
-        - name: division_name
-          description: Name of the NHL division
-        - name: division_short_name
-          description: Short name for the NHL division
-        - name: division_url
-          description: URL endpoint
-        - name: division_abbreviation
-          description: Abbreviated NHL conference name
-        - name: is_active
-          description: Whether or not the conference is still active
+  - name: stg_meltano__divisions
+    description: Staged NHL division data from the NHL-API
+    columns:
+      - name: id
+        description: Unique identifier for NHL divisions
+        tests:
+          - unique
+          - not_null
+      - name: conference_id
+        description: Foreign key that maps to the NHL conference
+      - name: division_name
+        description: Name of the NHL division
+      - name: division_short_name
+        description: Short name for the NHL division
+      - name: division_url
+        description: URL endpoint
+      - name: division_abbreviation
+        description: Abbreviated NHL conference name
+      - name: is_active
+        description: Whether or not the conference is still active
 
-    - name: stg_meltano__draft
-      description: Staged NHL entry draft data from the NHL-API
-      columns:
-        - name: id
-          description: Unique identifier for an NHL rookie draft (generated via dbt_utils.surrogate_key)
-          tests:
-            - unique
-            - not_null
-        - name: overall_pick_id
-          description: Unique identifier for an NHL rookie draft (draft year + overall pick)
-        - name: draft_prospect_id
-          description: Foreign key that maps to an NHL draft prospect
-        - name: draft_team_id
-          description: Foreign key that maps to the NHL team that drafted the NHL prospect
-        - name: draft_year
-          description: Year of the NHL entry draft
-        - name: draft_overall_pick
-          description: The overall pick in the NHL entry draft. For example, `1` is the first overall pick
-        - name: draft_round
-          description: The drafting round that the selection was made in
-        - name: draft_round_pick
-          description: The pick in the NHL entry draft made relative to the round
-        - name: draft_prospect_name
-          description: Name of the drafted NHL prospect
-        - name: draft_url
-          description: URL endpoint
-        - name: draft_team_name
-          description: Name of the NHL team that drafted the NHL prospect
+  - name: stg_meltano__draft
+    description: Staged NHL entry draft data from the NHL-API
+    columns:
+      - name: id
+        description: Unique identifier for an NHL rookie draft (generated via dbt_utils.surrogate_key)
+        tests:
+          - unique
+          - not_null
+      - name: overall_pick_id
+        description: Unique identifier for an NHL rookie draft (draft year + overall pick)
+      - name: draft_prospect_id
+        description: Foreign key that maps to an NHL draft prospect
+      - name: draft_team_id
+        description: Foreign key that maps to the NHL team that drafted the NHL prospect
+      - name: draft_year
+        description: Year of the NHL entry draft
+      - name: draft_overall_pick
+        description: The overall pick in the NHL entry draft. For example, `1` is the first overall pick
+      - name: draft_round
+        description: The drafting round that the selection was made in
+      - name: draft_round_pick
+        description: The pick in the NHL entry draft made relative to the round
+      - name: draft_prospect_name
+        description: Name of the drafted NHL prospect
+      - name: draft_url
+        description: URL endpoint
+      - name: draft_team_name
+        description: Name of the NHL team that drafted the NHL prospect
 
-    - name: stg_meltano__draft_prospects
-      description: Staged NHL draft_prospects data from the NHL-API
-      columns:
-        - name: id
-          description: Unique identifier for a drafted NHL prospect
-          tests:
-            - unique
-            - not_null
-        - name: prospect_player_id
-          description: Foreign key that maps to an NHL player ID
-        - name: prospect_category_id
-          description: Foreign key that maps to one of the four prospect categories - North American Skater (1), European Skater (2), North American Goalie (3) or European Goalie (4)
-        - name: prospect_first_name
-          description: First name of the NHL prospect
-        - name: prospect_last_name
-          description: Last name of the NHL prospect
-        - name: prospect_full_name
-          description: Full name of the NHL prospect
-        - name: prospect_birth_date
-          description: Birth date of the NHL prospect
-        - name: prospect_age_years
-          description: Age in years of the NHL prospect
-        - name: prospect_age_days
-          description: Age in days of the NHL prospect
-        - name: prospect_birth_city
-          description: Birth city of the NHL prospect
-        - name: prospect_birth_state_province
-          description: Birth state or province of the NHL prospect
-        - name: prospect_birth_country
-          description: Birth country of the NHL prospect
-        - name: prospect_height
-          description: Imperial height, in feet and inches (e.g. 5'10")
-        - name: prospect_weight
-          description: Imperial weight, in pounds (e.g. 140)
-        - name: prospect_shoots_catches
-          description: The handedness of the NHL prospect (e.g. R = right, L = left)
-        - name: prospect_position_name
-          description: Name of the position (e.g. Center, Left Wing, Defenseman)
-        - name: prospect_position_abbreviation
-          description: Abbreviation of the position (e.g. C, LW, D)
-        - name: prospect_draft_status
-          description: Unknown (e.g. NHL-10, NHL-54)
-        - name: prospect_category_name
-          description: Describes four prospect categories - North American Skater, European Skater, North American Goalie or European Goalie
-        - name: prospect_category_short_name
-          description: Describes four prospect categories - NA Skater, Euro Skater, NA Goalie or Euro Goalie
-        - name: prospect_amateur_team_name
-          description: Name of the amateur team that the NHL prospect plays for - unknown when, lots of nulls
-        - name: prospect_amateur_team_url
-          description: URL endpoint for amateur team
-        - name: prospect_rank_midterm
-          description: Unknown, lots of nulls
-        - name: prospect_rank_draft_year
-          description: Unknown, lots of null
-        - name: prospect_url
-          description: URL endpoint for the prospect
+  - name: stg_meltano__draft_prospects
+    description: Staged NHL draft_prospects data from the NHL-API
+    columns:
+      - name: id
+        description: Unique identifier for a drafted NHL prospect
+        tests:
+          - unique
+          - not_null
+      - name: prospect_player_id
+        description: Foreign key that maps to an NHL player ID
+      - name: prospect_category_id
+        description: Foreign key that maps to one of the four prospect categories - North American Skater (1), European Skater (2), North American Goalie (3) or European Goalie (4)
+      - name: prospect_first_name
+        description: First name of the NHL prospect
+      - name: prospect_last_name
+        description: Last name of the NHL prospect
+      - name: prospect_full_name
+        description: Full name of the NHL prospect
+      - name: prospect_birth_date
+        description: Birth date of the NHL prospect
+      - name: prospect_age_years
+        description: Age in years of the NHL prospect
+      - name: prospect_age_days
+        description: Age in days of the NHL prospect
+      - name: prospect_birth_city
+        description: Birth city of the NHL prospect
+      - name: prospect_birth_state_province
+        description: Birth state or province of the NHL prospect
+      - name: prospect_birth_country
+        description: Birth country of the NHL prospect
+      - name: prospect_height
+        description: Imperial height, in feet and inches (e.g. 5'10")
+      - name: prospect_weight
+        description: Imperial weight, in pounds (e.g. 140)
+      - name: prospect_shoots_catches
+        description: The handedness of the NHL prospect (e.g. R = right, L = left)
+      - name: prospect_position_name
+        description: Name of the position (e.g. Center, Left Wing, Defenseman)
+      - name: prospect_position_abbreviation
+        description: Abbreviation of the position (e.g. C, LW, D)
+      - name: prospect_draft_status
+        description: Unknown (e.g. NHL-10, NHL-54)
+      - name: prospect_category_name
+        description: Describes four prospect categories - North American Skater, European Skater, North American Goalie or European Goalie
+      - name: prospect_category_short_name
+        description: Describes four prospect categories - NA Skater, Euro Skater, NA Goalie or Euro Goalie
+      - name: prospect_amateur_team_name
+        description: Name of the amateur team that the NHL prospect plays for - unknown when, lots of nulls
+      - name: prospect_amateur_team_url
+        description: URL endpoint for amateur team
+      - name: prospect_rank_midterm
+        description: Unknown, lots of nulls
+      - name: prospect_rank_draft_year
+        description: Unknown, lots of null
+      - name: prospect_url
+        description: URL endpoint for the prospect
 
-    - name: stg_meltano__boxscore
-      description: Staged NHL boxscore data from the NHL-API (will be replaced/enhanced by linescore)
-      columns:
-        - name: id
-          description: |
-            Unique identifier for an NHL game (game_id)
-            {{ doc("game_id_description") }}
-          tests:
-            - unique
-            - not_null
+  - name: stg_meltano__boxscore
+    description: Staged NHL boxscore data from the NHL-API (will be replaced/enhanced by linescore)
+    columns:
+      - name: id
+        description: |
+          Unique identifier for an NHL game (game_id)
+          {{ doc("game_id_description") }}
+        tests:
+          - unique
+          - not_null
 
-    - name: stg_meltano__linescore
-      description: Staged NHL linescore data from the NHL-API (enhancement on stg_meltano__boxscore)
-      columns:
-        - name: id
-          description: |
-            Unique identifier for an NHL game (game_id)
-            {{ doc("game_id_description") }}
-          tests:
-            - unique
-            - not_null
+  - name: stg_meltano__linescore
+    description: Staged NHL linescore data from the NHL-API (enhancement on stg_meltano__boxscore)
+    columns:
+      - name: id
+        description: |
+          Unique identifier for an NHL game (game_id)
+          {{ doc("game_id_description") }}
+        tests:
+          - unique
+          - not_null
 
-   - name: stg_meltano__games
-      description: Staged NHL boxscore & linescore data from the NHL-API
-      columns:
-        - name: id
-          description: |
-            Unique identifier for an NHL game (game_id)
-            {{ doc("game_id_description") }}          tests:
-            - unique
-            - not_null
-        - name: game_id
-          description: |
-            Unique identifier for an NHL game (game_id)
-            {{ doc("game_id_description") }}        
-        - name: home_team_id
-          description: Foreign key that maps to an NHL team (home team)
-        - name: away_team_id
-          description: Foreign key that maps to an NHL team (away team)
-        - name: game_score_description
-          description: Description of the NHL game scoreline
-        - name: game_matchup_description
-          description: Description of the participants in the NHL game
-        - name: game_winning_team_id
-          description: Winning team's team ID
-        - name: game_winning_team_name
-          description: Winning team's team name
-        - name: game_absolute_goal_differential
-          description: Absolute goal differential between the winner and loser
-        - name: home_team_goals
-          description: Number of goals scored by the home team
-        - name: away_team_goals
-          description: Number of goals scored by the away team
-        - name: home_team_name
-          description: Home team's team name
-        - name: home_team_pim
-          description: Number of penalty minutes taken by the home team
-        - name: home_team_shots
-          description: Number of shots taken by the home team
-        - name: home_team_powerplay_goals
-          description: Number of powerplay goals scored by the home team
-        - name: home_team_powerplay_opportunities
-          description: Number of powerplay opportunities had by the home team
-        - name: home_team_faceoff_percentage
-          description: Faceoff percentage (wins / attempts) of the home team
-        - name: home_team_blocked
-          description: Number of blocked shots by the home team
-        - name: home_team_takeaways
-          description: Number of takeaways made by the home team
-        - name: home_team_giveaways
-          description: Number of giveaways faulted for by the home team
-        - name: home_team_hits
-          description: Number of hits made by the home team
-        - name: away_team_name
-          description: Away team's team name
-        - name: away_team_pim
-          description: Number of penalty minutes taken by the away team
-        - name: away_team_shots
-          description: Number of shots taken by the away team
-        - name: away_team_powerplay_goals
-          description: Number of powerplay goals scored by the away team
-        - name: away_team_powerplay_opportunities
-          description: Number of powerplay opportunities had by the away team
-        - name: away_team_faceoff_percentage
-          description: Faceoff percentage (wins / attempts) of the away team
-        - name: away_team_blocked
-          description: Number of blocked shots by the away team
-        - name: away_team_takeaways
-          description: Number of takeaways made by the away team
-        - name: away_team_giveaways
-          description: Number of giveaways faulted for by the away team
-        - name: away_team_hits
-          description: Number of hits made by the away team
+  - name: stg_meltano__games
+    description: Staged NHL boxscore & linescore data from the NHL-API
+    columns:
+      - name: id
+        description: |
+          Unique identifier for an NHL game (game_id)
+          {{ doc("game_id_description") }}          tests:
+          - unique
+          - not_null
+      - name: game_id
+        description: |
+          Unique identifier for an NHL game (game_id)
+          {{ doc("game_id_description") }}        
+      - name: home_team_id
+        description: Foreign key that maps to an NHL team (home team)
+      - name: away_team_id
+        description: Foreign key that maps to an NHL team (away team)
+      - name: game_score_description
+        description: Description of the NHL game scoreline
+      - name: game_matchup_description
+        description: Description of the participants in the NHL game
+      - name: game_winning_team_id
+        description: Winning team's team ID
+      - name: game_winning_team_name
+        description: Winning team's team name
+      - name: game_absolute_goal_differential
+        description: Absolute goal differential between the winner and loser
+      - name: home_team_goals
+        description: Number of goals scored by the home team
+      - name: away_team_goals
+        description: Number of goals scored by the away team
+      - name: home_team_name
+        description: Home team's team name
+      - name: home_team_pim
+        description: Number of penalty minutes taken by the home team
+      - name: home_team_shots
+        description: Number of shots taken by the home team
+      - name: home_team_powerplay_goals
+        description: Number of powerplay goals scored by the home team
+      - name: home_team_powerplay_opportunities
+        description: Number of powerplay opportunities had by the home team
+      - name: home_team_faceoff_percentage
+        description: Faceoff percentage (wins / attempts) of the home team
+      - name: home_team_blocked
+        description: Number of blocked shots by the home team
+      - name: home_team_takeaways
+        description: Number of takeaways made by the home team
+      - name: home_team_giveaways
+        description: Number of giveaways faulted for by the home team
+      - name: home_team_hits
+        description: Number of hits made by the home team
+      - name: away_team_name
+        description: Away team's team name
+      - name: away_team_pim
+        description: Number of penalty minutes taken by the away team
+      - name: away_team_shots
+        description: Number of shots taken by the away team
+      - name: away_team_powerplay_goals
+        description: Number of powerplay goals scored by the away team
+      - name: away_team_powerplay_opportunities
+        description: Number of powerplay opportunities had by the away team
+      - name: away_team_faceoff_percentage
+        description: Faceoff percentage (wins / attempts) of the away team
+      - name: away_team_blocked
+        description: Number of blocked shots by the away team
+      - name: away_team_takeaways
+        description: Number of takeaways made by the away team
+      - name: away_team_giveaways
+        description: Number of giveaways faulted for by the away team
+      - name: away_team_hits
+        description: Number of hits made by the away team
 
-    - name: stg_meltano__boxscore_team
-      description: Staged NHL boxscore game data from the NHL-API (game-team level)
-      columns:
-        - name: id
-          description: Unique identifier for an team's involvement in an NHL game (game_id + team_id)
-          tests:
-            - unique
-            - not_null
-        - name: game_id
-          description: |
-            Foreign key that maps to the NHL game ID - each game should have 2 rows in this table for each team involved in the game
-            {{ doc("game_id_description") }}
-        - name: team_id
-          description: Foreign key that maps to the NHL team ID - each row represents a team playing in a game
-        - name: team_type
-          description: Describes the Away / Home status for each team playing in a game
-        - name: team_name
-          description: Name of the NHL team
-        - name: team_winner
-          description: True of the team scored more than the opposing team, False if the team scored less than the opposing team, NULL for Shootout results (will be fixed by linescore data, boxscore does not tell us the result of a shootout)
-        - name: team_goals
-          description: Number of goals scored by the team
-        - name: team_goal_differential
-          description: The difference between the number of goals scored, and the number of goals allowed by the team
-        - name: team_pim
-          description:  The number of penalties in minutes:seconds against the team
-        - name: team_shots
-          description: The number of shots (unsure if this is on goal or attempts) for the team
-        - name: team_powerplay_goals
-          description: The number of powerplay goals for the team
-        - name: team_powerplay_opportunities
-          description: The number of powerplay opportunities for the team
-        - name: team_faceoff_percentage
-          description:  The percentage of faceoffs won by the team (e.g. 100 * (faceoff wins / faceoff attempts))
-        - name: team_blocked
-          description: The number of blocked shots for the team
-        - name: team_takeaways
-          description: The number of takeaways for the team
-        - name: team_giveaways
-          description: The number of giveaways for the team
-        - name: team_hits
-          description: The number of hits for the team
+  - name: stg_meltano__boxscore_team
+    description: Staged NHL boxscore game data from the NHL-API (game-team level)
+    columns:
+      - name: id
+        description: Unique identifier for an team's involvement in an NHL game (game_id + team_id)
+        tests:
+          - unique
+          - not_null
+      - name: game_id
+        description: |
+          Foreign key that maps to the NHL game ID - each game should have 2 rows in this table for each team involved in the game
+          {{ doc("game_id_description") }}
+      - name: team_id
+        description: Foreign key that maps to the NHL team ID - each row represents a team playing in a game
+      - name: team_type
+        description: Describes the Away / Home status for each team playing in a game
+      - name: team_name
+        description: Name of the NHL team
+      - name: team_winner
+        description: True of the team scored more than the opposing team, False if the team scored less than the opposing team, NULL for Shootout results (will be fixed by linescore data, boxscore does not tell us the result of a shootout)
+      - name: team_goals
+        description: Number of goals scored by the team
+      - name: team_goal_differential
+        description: The difference between the number of goals scored, and the number of goals allowed by the team
+      - name: team_pim
+        description:  The number of penalties in minutes:seconds against the team
+      - name: team_shots
+        description: The number of shots (unsure if this is on goal or attempts) for the team
+      - name: team_powerplay_goals
+        description: The number of powerplay goals for the team
+      - name: team_powerplay_opportunities
+        description: The number of powerplay opportunities for the team
+      - name: team_faceoff_percentage
+        description:  The percentage of faceoffs won by the team (e.g. 100 * (faceoff wins / faceoff attempts))
+      - name: team_blocked
+        description: The number of blocked shots for the team
+      - name: team_takeaways
+        description: The number of takeaways for the team
+      - name: team_giveaways
+        description: The number of giveaways for the team
+      - name: team_hits
+        description: The number of hits for the team
 
-    - name: stg_meltano__boxscore_player
-      description: Staged NHL boxscore player data from the NHL-API (game-player level). Each row represents an individual player's summarized activity in an NHL game
-      columns:
-        - name: id
-          description: Unique identifier for a player's summarized activity in an NHL game (game_id + team_id + player_id)
-          tests:
-            - unique
-            - not_null
-        - name: game_id
-          description: |
-            Foreign key that maps to an NHL game ID
-            {{ doc("game_id_description") }}
-        - name: team_id
-          description: Foreign key that maps to an NHL team ID
-        - name: player_id
-          description: Foreign key that maps to an NHL player ID
-        - name: team_name
-          description: Name of the NHL team
-        - name: team_type
-          description: Describes the Away / Home status for the team that the player belonged to in that game
-        - name: player_full_name
-          description: Full name of the NHL player
-        - name: player_roster_status
-          description: Roster status of the NHL player (e.g. Y, N, I)
-        - name: player_position_code
-          description: Position code (e.g. C, LW, D)
-        - name: time_on_ice
-          description: Time on ice in minutes:seconds (e.g. 21:30)
-        - name: assists
-          description: Number of assists (primary & secondary)
-        - name: goals
-          description: Number of goals scored
-        - name: shots
-          description: Number of shots taken
-        - name: hits
-          description: Number of hits made
-        - name: powerplay_goals
-          description: Number of powerplay goals scored
-        - name: powerplay_assists
-          description: Number of powerplay assists (primary & secondary)
-        - name: penalty_minutes
-          description: Number of penalties taken in minutes
-        - name: faceoff_wins
-          description: Number of faceoffs won
-        - name: faceoff_taken
-          description: Number of faceoffs taken
-        - name: takeaways
-          description: Number of takeaways made
-        - name: giveaways
-          description: Number of giveaways faulted for
-        - name: short_handed_goals
-          description: Number of short-handed goals scored
-        - name: short_handed_assists
-          description: Number of short-handed assists made
-        - name: blocked
-          description: Number of blocked shots
-        - name: plus_minus
-          description: Total plus minus in the game - plus for every goal scored while on the ice for, minus for every goal allowed while on the ice
-        - name: even_time_on_ice
-          description: Time on ice in minutes:seconds at event-strength (5v5)
-        - name: powerplay_time_on_ice
-          description: Time on ice in minutes:seconds on the man advantage / powerplay (5v4, 5v3, or 4v3)
-        - name: short_handed_time_on_ice
-          description: Time on ice in minutes:seconds while short-handed / on the penalty kill (4v5, 3v5, or 3v4)
-        - name: pim
-          description: Penalties in minutes:seconds
-        - name: saves
-          description: Number of saves made
-        - name: powerplay_saves
-          description: Number of saves made on the powerplay
-        - name: short_handed_saves
-          description: Number of saves made on the penalty kill / short-handed
-        - name: even_saves
-          description: Number of saves made at event strength
-        - name: short_handed_shots_against
-          description: Number of shots against on the penalth kill / short-handed
-        - name: even_shots_against
-          description:  Number of shots against at event strength
-        - name: powerplay_shots_against
-          description: Number of shots against on the powerplay / mad advantage
-        - name: decision
-          description: Win (W) or Loss (L) for goalies only (NULL if player)
-        - name: save_percentage
-          description: Percentage of shots faced that were saved (100% * (Number of shots saved / Number of shots))
-        - name: powerplay_save_percentage
-          description:  Percentage of shots faced on the powerplay that were saved (100% * (Number of shots saved / Number of shots))
-        - name: even_strength_save_percentage
-          description:  Percentage of shots faced at even strength that were saved (100% * (Number of shots saved / Number of shots))
+  - name: stg_meltano__boxscore_player
+    description: Staged NHL boxscore player data from the NHL-API (game-player level). Each row represents an individual player's summarized activity in an NHL game
+    columns:
+      - name: id
+        description: Unique identifier for a player's summarized activity in an NHL game (game_id + team_id + player_id)
+        tests:
+          - unique
+          - not_null
+      - name: game_id
+        description: |
+          Foreign key that maps to an NHL game ID
+          {{ doc("game_id_description") }}
+      - name: team_id
+        description: Foreign key that maps to an NHL team ID
+      - name: player_id
+        description: Foreign key that maps to an NHL player ID
+      - name: team_name
+        description: Name of the NHL team
+      - name: team_type
+        description: Describes the Away / Home status for the team that the player belonged to in that game
+      - name: player_full_name
+        description: Full name of the NHL player
+      - name: player_roster_status
+        description: Roster status of the NHL player (e.g. Y, N, I)
+      - name: player_position_code
+        description: Position code (e.g. C, LW, D)
+      - name: time_on_ice
+        description: Time on ice in minutes:seconds (e.g. 21:30)
+      - name: assists
+        description: Number of assists (primary & secondary)
+      - name: goals
+        description: Number of goals scored
+      - name: shots
+        description: Number of shots taken
+      - name: hits
+        description: Number of hits made
+      - name: powerplay_goals
+        description: Number of powerplay goals scored
+      - name: powerplay_assists
+        description: Number of powerplay assists (primary & secondary)
+      - name: penalty_minutes
+        description: Number of penalties taken in minutes
+      - name: faceoff_wins
+        description: Number of faceoffs won
+      - name: faceoff_taken
+        description: Number of faceoffs taken
+      - name: takeaways
+        description: Number of takeaways made
+      - name: giveaways
+        description: Number of giveaways faulted for
+      - name: short_handed_goals
+        description: Number of short-handed goals scored
+      - name: short_handed_assists
+        description: Number of short-handed assists made
+      - name: blocked
+        description: Number of blocked shots
+      - name: plus_minus
+        description: Total plus minus in the game - plus for every goal scored while on the ice for, minus for every goal allowed while on the ice
+      - name: even_time_on_ice
+        description: Time on ice in minutes:seconds at event-strength (5v5)
+      - name: powerplay_time_on_ice
+        description: Time on ice in minutes:seconds on the man advantage / powerplay (5v4, 5v3, or 4v3)
+      - name: short_handed_time_on_ice
+        description: Time on ice in minutes:seconds while short-handed / on the penalty kill (4v5, 3v5, or 3v4)
+      - name: pim
+        description: Penalties in minutes:seconds
+      - name: saves
+        description: Number of saves made
+      - name: powerplay_saves
+        description: Number of saves made on the powerplay
+      - name: short_handed_saves
+        description: Number of saves made on the penalty kill / short-handed
+      - name: even_saves
+        description: Number of saves made at event strength
+      - name: short_handed_shots_against
+        description: Number of shots against on the penalth kill / short-handed
+      - name: even_shots_against
+        description:  Number of shots against at event strength
+      - name: powerplay_shots_against
+        description: Number of shots against on the powerplay / mad advantage
+      - name: decision
+        description: Win (W) or Loss (L) for goalies only (NULL if player)
+      - name: save_percentage
+        description: Percentage of shots faced that were saved (100% * (Number of shots saved / Number of shots))
+      - name: powerplay_save_percentage
+        description:  Percentage of shots faced on the powerplay that were saved (100% * (Number of shots saved / Number of shots))
+      - name: even_strength_save_percentage
+        description:  Percentage of shots faced at even strength that were saved (100% * (Number of shots saved / Number of shots))
 
 
-    - name: stg_meltano__live_plays
-      description: Staged NHL event level data from the NHL-API (player-play level)
-      columns:
-        - name: id
-          description: Unique identifier for a player's event-level activity in an NHL game (game_id + team_id + player_id + event_id)
-          tests:
-            - unique
-            - not_null
-        - name: game_id
-          description: |
-            Foreign key that maps to an NHL game ID
-            {{ doc("game_id_description") }}
-        - name: event_idx
-          description: Foreign key that maps to the sequence of the event relative to that game, in ascending order (e.g. 1 = first event, 2 - second event)
-        - name: event_id
-          description: Foreign key that maps to a distinct event ID
-        - name: player_id
-          description: Foreign key that maps to an NHL player ID
-        - name: team_id
-          description: Foreign key that maps to an NHL team ID
-        - name: player_role
-          description: The role of the player in context to the event (e.g. Hitter, Hitee, Shooter, Winner, Loser, etc.)
-        - name: player_role_team
-          description: The home / away status of the player's team
-        - name: event_type
-          description: Short description of the event type
-        - name: event_code
-          description: Event code that is unique at the game-event level (e.g. PHI8, PHI10)
-        - name: event_description
-          description: Long description of the event (repeated for all the player's involved in the event)
-        - name: play_x_coordinate
-          description: The x-coordinate of where the event took place on the ice
-        - name: play_y_coordinate
-          description: The y-coordinate of where the event took place on the ice
-        - name: play_period
-          description: The period in which the event occured (e.g. 3)
-        - name: play_period_type
-          description: The type of period in which the event occured (e.g. Regular)
-        - name: play_period_time_elapsed
-          description: The time in minutes elapsed in the period
-        - name: play_period_time_remaining
-          description: The time in minutes remaining in the period
-        - name: play_period_seconds_elapsed
-          description: The time in seconds elapsed in the period
-        - name: play_period_seconds_remaining
-          description: The time in seconds remaining the period
-        - name: play_total_seconds_elapsed
-          description: The time in seconds elapsed in the entire game
-        - name: play_total_seconds_remaining
-          description: The time in seconds remaining in the entire game
-        - name: play_time
-          description: A timestamp of the event (e.g. 2021-01-13T22:32:45Z)
-        - name: shots_away
-          description: Cumulative away team shots taken in the game at the point in time where the event occured
-        - name: shots_home
-          description:  Cumulative ome team shots taken in the game at the point in time where the event occured
-        - name: hits_away
-          description:  Cumulative away team hits made in the game at the point in time where the event occured
-        - name: hits_home
-          description:  Cumulative home team hits made in the game at the point in time where the event occured
-        - name: faceoffs_away
-          description:  Cumulative away team faceoffs won in the game at the point in time where the event occured
-        - name: faceoffs_home
-          description:  Cumulative home team faceoffs won in the game at the point in time where the event occured
-        - name: takeaways_away
-          description: Cumulative away team takeaways forced in the game at the point in time where the event occured
-        - name: takeaways_home
-          description: Cumulative home team takeaways forced in the game at the point in time where the event occured
-        - name: giveaways_away
-          description: Cumulative away team giveaways made in the game at the point in time where the event occured
-        - name: giveaways_home
-          description: Cumulative home team giveaways made in the game at the point in time where the event occured
-        - name: missedshots_away
-          description: Cumulative away team missed shots taken in the game at the point in time where the event occured
-        - name: missedshots_home
-          description: Cumulative home team missed shots taken in the game at the point in time where the event occured
-        - name: blockedshots_away
-          description: Cumulative away team blocked shots made in the game at the point in time where the event occured
-        - name: blockedshots_home
-          description: Cumulative home team blocked shots made in the game at the point in time where the event occured
-        - name: penalties_away
-          description: Cumulative away team penalties in minutes taken in the game at the point in time where the event occured
-        - name: penalties_home
-          description: Cumulative home team penalties in minutes taken in the game at the point in time where the event occured
-        - name: first_goal_scored
-          description: Whether or not the event in question was the first goal of the game (1 or 0)
-        - name: last_goal_scored
-          description: Whether or not the event in question was the last goal of the game (1 or 0)
-        - name: goals_away
-          description: Cumulative away team goals scored in the game at the point in time where the event occured
-        - name: goals_home
-          description: Cumulative home team goals scored in the game at the point in time where the event occured
-        - name: goal_difference_current
-          description: The absolute value difference in goals between the home and away teams in the game at the point in time where the event occured
-        - name: winning_team_current
-          description: The name of the team_type (e.g. "Tie", "Home" or "Away") for the team currently winning
-        - name: game_state_current
-          description: The current state of scoreboard (e.g. "Tie", "Close" (1 goal difference), "Buffer" (2 goal difference), "Comfortable" (3 goal difference), "Blowout" (4 goal difference))
-        - name: home_result_of_play
-          description: Description of the result of the current event / play for the home team (e.g. "No change", "Chase goal", "Tying goal scored", "Tying goal allowed", "Go-ahead goal scored, Buffer goal", "Go-ahead goal allowed")
-        - name: away_result_of_play
-          description: Description of the result of the current event / play for the away team (e.g. "No change", "Chase goal", "Tying goal scored", "Tying goal allowed", "Go-ahead goal scored, Buffer goal", "Go-ahead goal allowed")
-        - name: last_goal_game_winning
-          description: Whether or not the the current goal was the last goal and also the game winning goal (1 or 0)
-        - name: last_goal_game_tying
-          description: Whether or not the the current goal was the last goal and also the game tying goal (1 or 0)
-        - name: goals_home_lag
-          description: Cumulative home team goals scored in the game 1 play before the current play (e.g. if event prior to this event was a home team goal, and the current play was a hit, then the value for this column would be 1)
-        - name: goals_away_lag
-          description: Cumulative away team goals scored in the game 1 play before the current play (e.g. if event prior to this event was a away team goal, and the current play was a hit, then the value for this column would be 1)
-        - name: goal_difference_lag
-          description: The absolute value difference in goals between the home and away teams in the game using the home and away team lagged goals scored
-        - name: winning_team_lag
-          description: Determines the previously winning team (e.g. "Tie", "Home" or "Away") before the play in question
-        - name: game_state_lag
-          description: The previous state of scoreboard prior to the play in question (e.g. "Tie", "Close" (1 goal difference), "Buffer" (2 goal difference), "Comfortable" (3 goal difference), "Blowout" (4 goal difference))
+  - name: stg_meltano__live_plays
+    description: Staged NHL event level data from the NHL-API (player-play level)
+    columns:
+      - name: id
+        description: Unique identifier for a player's event-level activity in an NHL game (game_id + team_id + player_id + event_id)
+        tests:
+          - unique
+          - not_null
+      - name: game_id
+        description: |
+          Foreign key that maps to an NHL game ID
+          {{ doc("game_id_description") }}
+      - name: event_idx
+        description: Foreign key that maps to the sequence of the event relative to that game, in ascending order (e.g. 1 = first event, 2 - second event)
+      - name: event_id
+        description: Foreign key that maps to a distinct event ID
+      - name: player_id
+        description: Foreign key that maps to an NHL player ID
+      - name: team_id
+        description: Foreign key that maps to an NHL team ID
+      - name: player_role
+        description: The role of the player in context to the event (e.g. Hitter, Hitee, Shooter, Winner, Loser, etc.)
+      - name: player_role_team
+        description: The home / away status of the player's team
+      - name: event_type
+        description: Short description of the event type
+      - name: event_code
+        description: Event code that is unique at the game-event level (e.g. PHI8, PHI10)
+      - name: event_description
+        description: Long description of the event (repeated for all the player's involved in the event)
+      - name: play_x_coordinate
+        description: The x-coordinate of where the event took place on the ice
+      - name: play_y_coordinate
+        description: The y-coordinate of where the event took place on the ice
+      - name: play_period
+        description: The period in which the event occured (e.g. 3)
+      - name: play_period_type
+        description: The type of period in which the event occured (e.g. Regular)
+      - name: play_period_time_elapsed
+        description: The time in minutes elapsed in the period
+      - name: play_period_time_remaining
+        description: The time in minutes remaining in the period
+      - name: play_period_seconds_elapsed
+        description: The time in seconds elapsed in the period
+      - name: play_period_seconds_remaining
+        description: The time in seconds remaining the period
+      - name: play_total_seconds_elapsed
+        description: The time in seconds elapsed in the entire game
+      - name: play_total_seconds_remaining
+        description: The time in seconds remaining in the entire game
+      - name: play_time
+        description: A timestamp of the event (e.g. 2021-01-13T22:32:45Z)
+      - name: shots_away
+        description: Cumulative away team shots taken in the game at the point in time where the event occured
+      - name: shots_home
+        description:  Cumulative ome team shots taken in the game at the point in time where the event occured
+      - name: hits_away
+        description:  Cumulative away team hits made in the game at the point in time where the event occured
+      - name: hits_home
+        description:  Cumulative home team hits made in the game at the point in time where the event occured
+      - name: faceoffs_away
+        description:  Cumulative away team faceoffs won in the game at the point in time where the event occured
+      - name: faceoffs_home
+        description:  Cumulative home team faceoffs won in the game at the point in time where the event occured
+      - name: takeaways_away
+        description: Cumulative away team takeaways forced in the game at the point in time where the event occured
+      - name: takeaways_home
+        description: Cumulative home team takeaways forced in the game at the point in time where the event occured
+      - name: giveaways_away
+        description: Cumulative away team giveaways made in the game at the point in time where the event occured
+      - name: giveaways_home
+        description: Cumulative home team giveaways made in the game at the point in time where the event occured
+      - name: missedshots_away
+        description: Cumulative away team missed shots taken in the game at the point in time where the event occured
+      - name: missedshots_home
+        description: Cumulative home team missed shots taken in the game at the point in time where the event occured
+      - name: blockedshots_away
+        description: Cumulative away team blocked shots made in the game at the point in time where the event occured
+      - name: blockedshots_home
+        description: Cumulative home team blocked shots made in the game at the point in time where the event occured
+      - name: penalties_away
+        description: Cumulative away team penalties in minutes taken in the game at the point in time where the event occured
+      - name: penalties_home
+        description: Cumulative home team penalties in minutes taken in the game at the point in time where the event occured
+      - name: first_goal_scored
+        description: Whether or not the event in question was the first goal of the game (1 or 0)
+      - name: last_goal_scored
+        description: Whether or not the event in question was the last goal of the game (1 or 0)
+      - name: goals_away
+        description: Cumulative away team goals scored in the game at the point in time where the event occured
+      - name: goals_home
+        description: Cumulative home team goals scored in the game at the point in time where the event occured
+      - name: goal_difference_current
+        description: The absolute value difference in goals between the home and away teams in the game at the point in time where the event occured
+      - name: winning_team_current
+        description: The name of the team_type (e.g. "Tie", "Home" or "Away") for the team currently winning
+      - name: game_state_current
+        description: The current state of scoreboard (e.g. "Tie", "Close" (1 goal difference), "Buffer" (2 goal difference), "Comfortable" (3 goal difference), "Blowout" (4 goal difference))
+      - name: home_result_of_play
+        description: Description of the result of the current event / play for the home team (e.g. "No change", "Chase goal", "Tying goal scored", "Tying goal allowed", "Go-ahead goal scored, Buffer goal", "Go-ahead goal allowed")
+      - name: away_result_of_play
+        description: Description of the result of the current event / play for the away team (e.g. "No change", "Chase goal", "Tying goal scored", "Tying goal allowed", "Go-ahead goal scored, Buffer goal", "Go-ahead goal allowed")
+      - name: last_goal_game_winning
+        description: Whether or not the the current goal was the last goal and also the game winning goal (1 or 0)
+      - name: last_goal_game_tying
+        description: Whether or not the the current goal was the last goal and also the game tying goal (1 or 0)
+      - name: goals_home_lag
+        description: Cumulative home team goals scored in the game 1 play before the current play (e.g. if event prior to this event was a home team goal, and the current play was a hit, then the value for this column would be 1)
+      - name: goals_away_lag
+        description: Cumulative away team goals scored in the game 1 play before the current play (e.g. if event prior to this event was a away team goal, and the current play was a hit, then the value for this column would be 1)
+      - name: goal_difference_lag
+        description: The absolute value difference in goals between the home and away teams in the game using the home and away team lagged goals scored
+      - name: winning_team_lag
+        description: Determines the previously winning team (e.g. "Tie", "Home" or "Away") before the play in question
+      - name: game_state_lag
+        description: The previous state of scoreboard prior to the play in question (e.g. "Tie", "Close" (1 goal difference), "Buffer" (2 goal difference), "Comfortable" (3 goal difference), "Blowout" (4 goal difference))
 
-    - name: stg_meltano__players
-      description: Staged NHL player data from the NHL-API
-      columns:
-        - name: id
-          description: Unique identifier for an NHL player
-          tests:
-            - unique
-            - not_null
-        - name: current_team_id
-          description: Foreign key that maps to the NHL team ID that the NHL player currently plays for
-        - name: full_name
-          description: Full name of the NHL player
-        - name: player_url
-          description: URL endpoint for NHL player
-        - name: first_name
-          description: First name of the NHL player
-        - name: last_name
-          description: Last name of the NHL player
-        - name: primary_number
-          description: Number that the player usually wears
-        - name: birth_date
-          description: Birth date of the NHL player
-        - name: current_age
-          description: Age in years of the NHL player
-        - name: birth_city
-          description: Birth city of the NHL player
-        - name: birth_state_province
-          description: Birth state or province of the NHL player
-        - name: birth_country
-          description: Birth country of the NHL player
-        - name: nationality
-          description: Nationality of the NHL player
-        - name: height
-          description: Imperial height, in feet and inches (e.g. 5'10")
-        - name: weight
-          description: Imperial weight, in pounds (e.g. 140)
-        - name: is_active
-          description: Whether or not the NHL player is currently active (True / False)
-        - name: is_alternate_captain
-          description: Whether or not the NHL player is currently an alternate captain for their team (True / False)
-        - name: is_captain
-          description: Whether or not the NHL player is currently the captain of their team (True / False)
-        - name: is_rookie
-          description: Whether or not the NHL player is currently a rookie (True / False)
-        - name: shoots_catches
-          description: The handedness of the NHL player (e.g. R = right, L = left)
-        - name: roster_status
-          description: Roster status of the NHL player (e.g. Y, N, I)
-        - name: current_team_name
-          description: Name of the NHL team the player currently plays for
-        - name: current_team_url
-          description: URL endpoint for current NHL team
-        - name: primary_position_code
-          description: Position code of the position most played (e.g. C, L, D)
-        - name: primary_position_name
-          description: Position name of the position most played (e.g. Center, Left Wing, Defenseman)
-        - name: primary_position_type
-          description: Position grouping for the position most played (e.g. Forward, Defenseman)
-        - name: primary_position_abbreviation
-          description: Position abbreviation of the position most played (e.g. C, LW, D)
-        - name: extracted_at
-          description: Timestamp that the data was retrieved
-        - name: loaded_at
-          description: Timestamp that the data was loaded
+  - name: stg_meltano__players
+    description: Staged NHL player data from the NHL-API
+    columns:
+      - name: id
+        description: Unique identifier for an NHL player
+        tests:
+          - unique
+          - not_null
+      - name: current_team_id
+        description: Foreign key that maps to the NHL team ID that the NHL player currently plays for
+      - name: full_name
+        description: Full name of the NHL player
+      - name: player_url
+        description: URL endpoint for NHL player
+      - name: first_name
+        description: First name of the NHL player
+      - name: last_name
+        description: Last name of the NHL player
+      - name: primary_number
+        description: Number that the player usually wears
+      - name: birth_date
+        description: Birth date of the NHL player
+      - name: current_age
+        description: Age in years of the NHL player
+      - name: birth_city
+        description: Birth city of the NHL player
+      - name: birth_state_province
+        description: Birth state or province of the NHL player
+      - name: birth_country
+        description: Birth country of the NHL player
+      - name: nationality
+        description: Nationality of the NHL player
+      - name: height
+        description: Imperial height, in feet and inches (e.g. 5'10")
+      - name: weight
+        description: Imperial weight, in pounds (e.g. 140)
+      - name: is_active
+        description: Whether or not the NHL player is currently active (True / False)
+      - name: is_alternate_captain
+        description: Whether or not the NHL player is currently an alternate captain for their team (True / False)
+      - name: is_captain
+        description: Whether or not the NHL player is currently the captain of their team (True / False)
+      - name: is_rookie
+        description: Whether or not the NHL player is currently a rookie (True / False)
+      - name: shoots_catches
+        description: The handedness of the NHL player (e.g. R = right, L = left)
+      - name: roster_status
+        description: Roster status of the NHL player (e.g. Y, N, I)
+      - name: current_team_name
+        description: Name of the NHL team the player currently plays for
+      - name: current_team_url
+        description: URL endpoint for current NHL team
+      - name: primary_position_code
+        description: Position code of the position most played (e.g. C, L, D)
+      - name: primary_position_name
+        description: Position name of the position most played (e.g. Center, Left Wing, Defenseman)
+      - name: primary_position_type
+        description: Position grouping for the position most played (e.g. Forward, Defenseman)
+      - name: primary_position_abbreviation
+        description: Position abbreviation of the position most played (e.g. C, LW, D)
+      - name: extracted_at
+        description: Timestamp that the data was retrieved
+      - name: loaded_at
+        description: Timestamp that the data was loaded
 
-    - name: stg_meltano__schedule
-      description: Staged NHL schedule data from the NHL-API
-      columns:
-        - name: id
-          description: Unique identifier for NHL scheduled games
-          tests:
-            - unique
-            - not_null
-        - name: game_id
-          description: |
-            Foreign key that maps to an NHL game
-            {{ doc("game_id_description") }}
-        - name: season_id
-          description: Foreign key that maps to an NHL season
-        - name: away_team_id
-          description: Foreign key that maps to an NHL team (away team)
-        - name: home_team_id
-          description: Foreign key that maps to an NHL team (home team)
-        - name: venue_id
-          description: Foreign key tha tmaps to a team's venu (home team)
-        - name: game_number
-          description: Four digit number that is unique to a game in the context of a season (e.g. 0002)
-        - name: url
-          description: URL endpoint for schedule
-        - name: game_type
-          description: Code for the type of game (e.g. R = regular season)
-        - name: game_date
-          description: Date that the game takes place (e.g. 2021-01-14)
-        - name: abstract_game_state
-          description: Game state (e.g. Final)
-        - name: coded_game_state
-          description: Coded game state (e.g. 7)
-        - name: detailed_state
-          description: Detailed game state (e.g. Final) - should be different that game state, but look similar
-        - name: status_code
-          description: Unknown - looks similar to code_game_state
-        - name: is_start_time_tbd
-          description: Whether or not the start time is still to be decided (True / False)
-        - name: away_team_wins
-          description: Cumulative number of wins for the away team for the given season (wins for the team at that point in time)
-        - name: away_team_losses
-          description: Cumulative number of losses for the away team for the given season (losses for the team at that point in time)
-        - name: away_team_ot
-          description: Cumulative number of overtime wins for the away team for the given season (overtime wins for the team at that point in time)
-        - name: away_team_type
-          description: Type of away team (e.g. League)
-        - name: away_team_score
-          description: Goals scored by the away team
-        - name: away_team_name
-          description: Away team name
-        - name: away_team_url
-          description: Away team URL endpoint
-        - name: home_team_wins
-          description: Cumulative number of wins for the home team for the given season (wins for the team at that point in time)
-        - name: home_team_losses
-          description: Cumulative number of losses for the home team for the given season (losses for the team at that point in time)
-        - name: home_team_ot
-          description: Cumulative number of overtime wins for the home team for the given season (overtime wins for the team at that point in time)
-        - name: home_team_type
-          description: Type of home team (e.g. League)
-        - name: home_team_score
-          description: Goals scored by the home team
-        - name: home_team_name
-          description: Home team name
-        - name: home_team_url
-          description: Home team URL endpoint
-        - name: venue_name
-          description: Home team's venue / arena that the teams played in
-        - name: venue_url
-          description: URL endpoint for the venue
-        - name: content_url
-          description: URL endpoint for the content
-        - name: extracted_at
-          description: Timestamp that the data was retrieved
-        - name: loaded_at
-          description: Timestamp that the data was loaded
+  - name: stg_meltano__schedule
+    description: Staged NHL schedule data from the NHL-API
+    columns:
+      - name: id
+        description: Unique identifier for NHL scheduled games
+        tests:
+          - unique
+          - not_null
+      - name: game_id
+        description: |
+          Foreign key that maps to an NHL game
+          {{ doc("game_id_description") }}
+      - name: season_id
+        description: Foreign key that maps to an NHL season
+      - name: away_team_id
+        description: Foreign key that maps to an NHL team (away team)
+      - name: home_team_id
+        description: Foreign key that maps to an NHL team (home team)
+      - name: venue_id
+        description: Foreign key tha tmaps to a team's venu (home team)
+      - name: game_number
+        description: Four digit number that is unique to a game in the context of a season (e.g. 0002)
+      - name: url
+        description: URL endpoint for schedule
+      - name: game_type
+        description: Code for the type of game (e.g. R = regular season)
+      - name: game_date
+        description: Date that the game takes place (e.g. 2021-01-14)
+      - name: abstract_game_state
+        description: Game state (e.g. Final)
+      - name: coded_game_state
+        description: Coded game state (e.g. 7)
+      - name: detailed_state
+        description: Detailed game state (e.g. Final) - should be different that game state, but look similar
+      - name: status_code
+        description: Unknown - looks similar to code_game_state
+      - name: is_start_time_tbd
+        description: Whether or not the start time is still to be decided (True / False)
+      - name: away_team_wins
+        description: Cumulative number of wins for the away team for the given season (wins for the team at that point in time)
+      - name: away_team_losses
+        description: Cumulative number of losses for the away team for the given season (losses for the team at that point in time)
+      - name: away_team_ot
+        description: Cumulative number of overtime wins for the away team for the given season (overtime wins for the team at that point in time)
+      - name: away_team_type
+        description: Type of away team (e.g. League)
+      - name: away_team_score
+        description: Goals scored by the away team
+      - name: away_team_name
+        description: Away team name
+      - name: away_team_url
+        description: Away team URL endpoint
+      - name: home_team_wins
+        description: Cumulative number of wins for the home team for the given season (wins for the team at that point in time)
+      - name: home_team_losses
+        description: Cumulative number of losses for the home team for the given season (losses for the team at that point in time)
+      - name: home_team_ot
+        description: Cumulative number of overtime wins for the home team for the given season (overtime wins for the team at that point in time)
+      - name: home_team_type
+        description: Type of home team (e.g. League)
+      - name: home_team_score
+        description: Goals scored by the home team
+      - name: home_team_name
+        description: Home team name
+      - name: home_team_url
+        description: Home team URL endpoint
+      - name: venue_name
+        description: Home team's venue / arena that the teams played in
+      - name: venue_url
+        description: URL endpoint for the venue
+      - name: content_url
+        description: URL endpoint for the content
+      - name: extracted_at
+        description: Timestamp that the data was retrieved
+      - name: loaded_at
+        description: Timestamp that the data was loaded
 
-    - name: stg_meltano__seasons
-      description: Staged NHL seasons data from the NHL-API
-      columns:
-        - name: id
-          description: Unique identifier for an NHL season (e.g. "20172018")
-          tests:
-            - unique
-            - not_null
-        - name: regular_season_start_date
-          description: The first date of the NHL regular season (e.g. "2017-10-04")
-        - name: regular_season_end_date
-          description: The last date of the NHL regular season (e.g. "2018-04-08")
-        - name: season_end_date
-          description: The last date of the NHL post season (e.g. "2018-06-07")
-        - name: number_of_games
-          description: The number of total games played by each NHL team
-        - name: has_ties_in_use
-          description: Whether or not ties were possible for that season (True / False)
-        - name: has_olympics_participation
-          description: Whether or not olympic participation at the NHL level was allowed for that season (True / False)
-        - name: has_conferences_in_use
-          description: Whether or not conferences were used for that season's playoff consideration (True / False)
-        - name: has_divisions_in_use
-          description: Whether or not divisions were used for that season's playoff consideration (True / False)
-        - name: has_wildcard_in_use
-          description: Whether or not wildcards were used for that season's playoff consideration (True / False)
-        - name: extracted_at
-          description: Timestamp that the data was retrieved
-        - name: loaded_at
-          description: Timestamp that the data was loaded
+  - name: stg_meltano__seasons
+    description: Staged NHL seasons data from the NHL-API
+    columns:
+      - name: id
+        description: Unique identifier for an NHL season (e.g. "20172018")
+        tests:
+          - unique
+          - not_null
+      - name: regular_season_start_date
+        description: The first date of the NHL regular season (e.g. "2017-10-04")
+      - name: regular_season_end_date
+        description: The last date of the NHL regular season (e.g. "2018-04-08")
+      - name: season_end_date
+        description: The last date of the NHL post season (e.g. "2018-06-07")
+      - name: number_of_games
+        description: The number of total games played by each NHL team
+      - name: has_ties_in_use
+        description: Whether or not ties were possible for that season (True / False)
+      - name: has_olympics_participation
+        description: Whether or not olympic participation at the NHL level was allowed for that season (True / False)
+      - name: has_conferences_in_use
+        description: Whether or not conferences were used for that season's playoff consideration (True / False)
+      - name: has_divisions_in_use
+        description: Whether or not divisions were used for that season's playoff consideration (True / False)
+      - name: has_wildcard_in_use
+        description: Whether or not wildcards were used for that season's playoff consideration (True / False)
+      - name: extracted_at
+        description: Timestamp that the data was retrieved
+      - name: loaded_at
+        description: Timestamp that the data was loaded
 
-    - name: stg_meltano__teams
-      description: Staged NHL teams data from the NHL-API
-      columns:
-        - name: id
-          description: Unique identifier for NHL teams
-          tests:
-            - unique
-            - not_null
-        - name: venue_timezone_id
-          description: Foreign key that maps to the timezone ID of the venue (e.g. America/Vancouver)
-        - name: division_id
-          description: Foreign key that maps to the division ID that the NHL team belongs to
-        - name: conference_id
-          description: Foreign key that maps to the conference ID that the NHL team belongs to
-        - name: franchise_id
-          description: Foreign key that maps to the franchise ID that the NHL originates from
-        - name: full_name
-          description: Full name of the NHL team (e.g. Vancouver Canucks)
-        - name: team_url
-          description: URL endpoint for the NHl team
-        - name: venue_name
-          description: Name of the venue / arena that the NHL team plays in
-        - name: venue_url
-          description: URL endpoint for the NHL team venue
-        - name: venue_city
-          description: City that the venue / arena is in
-        - name: venue_timezone_offset
-          description: Offset necessary to correct for timezone differences (e.g. Vancouver = -7)
-        - name: venue_timezone_name
-          description: Abbreviated timezone for the venue (e.g. PDT)
-        - name: abbreviation
-          description: Abbreviation for the NHL team (e.g. VAN)
-        - name: team_name
-          description: Second part of the team name (e.g. Canucks)
-        - name: location_name
-          description: First part of the team name (e.g. Vancouer)
-        - name: first_year_of_play
-          description: The inaugural year for the NHL team (e.g. 1970)
-        - name: division_name
-          description: Name of the division that the team currently plays in
-        - name: division_short_name
-          description: Short name for the division that the team currently plays in
-        - name: division_url
-          description: URL endpoint for division
-        - name: division_abbreviation
-          description: Abbreviated NHL division name (e.g. P)
-        - name: conference_name
-          description: Conference name that the team currently plays in
-        - name: conference_url
-          description: URL endpoint for the conference
-        - name: franchise_team_name
-          description: Name of the franchise (second part of full team name)
-        - name: franchise_url
-          description: URL endpoint for the franchise
-        - name: short_name
-          description: Slightly different short version of the team name
-        - name: official_site_url
-          description: Official site URL
-        - name: is_active
-          description: Whether or not the team is currently active in the NHL
-        - name: extracted_at
-          description: Timestamp that the data was retrieved
-        - name: loaded_at
-          description: Timestamp that the data was loaded
+  - name: stg_meltano__teams
+    description: Staged NHL teams data from the NHL-API
+    columns:
+      - name: id
+        description: Unique identifier for NHL teams
+        tests:
+          - unique
+          - not_null
+      - name: venue_timezone_id
+        description: Foreign key that maps to the timezone ID of the venue (e.g. America/Vancouver)
+      - name: division_id
+        description: Foreign key that maps to the division ID that the NHL team belongs to
+      - name: conference_id
+        description: Foreign key that maps to the conference ID that the NHL team belongs to
+      - name: franchise_id
+        description: Foreign key that maps to the franchise ID that the NHL originates from
+      - name: full_name
+        description: Full name of the NHL team (e.g. Vancouver Canucks)
+      - name: team_url
+        description: URL endpoint for the NHl team
+      - name: venue_name
+        description: Name of the venue / arena that the NHL team plays in
+      - name: venue_url
+        description: URL endpoint for the NHL team venue
+      - name: venue_city
+        description: City that the venue / arena is in
+      - name: venue_timezone_offset
+        description: Offset necessary to correct for timezone differences (e.g. Vancouver = -7)
+      - name: venue_timezone_name
+        description: Abbreviated timezone for the venue (e.g. PDT)
+      - name: abbreviation
+        description: Abbreviation for the NHL team (e.g. VAN)
+      - name: team_name
+        description: Second part of the team name (e.g. Canucks)
+      - name: location_name
+        description: First part of the team name (e.g. Vancouer)
+      - name: first_year_of_play
+        description: The inaugural year for the NHL team (e.g. 1970)
+      - name: division_name
+        description: Name of the division that the team currently plays in
+      - name: division_short_name
+        description: Short name for the division that the team currently plays in
+      - name: division_url
+        description: URL endpoint for division
+      - name: division_abbreviation
+        description: Abbreviated NHL division name (e.g. P)
+      - name: conference_name
+        description: Conference name that the team currently plays in
+      - name: conference_url
+        description: URL endpoint for the conference
+      - name: franchise_team_name
+        description: Name of the franchise (second part of full team name)
+      - name: franchise_url
+        description: URL endpoint for the franchise
+      - name: short_name
+        description: Slightly different short version of the team name
+      - name: official_site_url
+        description: Official site URL
+      - name: is_active
+        description: Whether or not the team is currently active in the NHL
+      - name: extracted_at
+        description: Timestamp that the data was retrieved
+      - name: loaded_at
+        description: Timestamp that the data was loaded

--- a/models/staging/stg_meltano__divisions.sql
+++ b/models/staging/stg_meltano__divisions.sql
@@ -7,7 +7,7 @@ SELECT
 
     /* Properties */
     ,divisions.name as division_name
-    ,divisions.nameshort as division_name_short
+    ,divisions.nameshort as division_short_name
     ,divisions.link as division_url
     ,divisions.abbreviation as division_abbreviation
     ,divisions.active as is_active

--- a/models/staging/stg_meltano__games.sql
+++ b/models/staging/stg_meltano__games.sql
@@ -48,11 +48,11 @@ with
             , boxscore.away_team_takeaways
             , boxscore.away_team_giveaways
             , boxscore.away_team_hits
-        from linescore
-        left join boxscore
-            on linescore.game_id = boxscore.game_id
-            and linescore.home_team_id = boxscore.home_team_id
-            and linescore.away_team_id = boxscore.away_team_id
+        from 
+            linescore
+            left join boxscore on linescore.game_id = boxscore.game_id
+                               and linescore.home_team_id = boxscore.home_team_id
+                               and linescore.away_team_id = boxscore.away_team_id
     )
 
 select * from final

--- a/models/utils/dates.sql
+++ b/models/utils/dates.sql
@@ -17,7 +17,8 @@ with date_spine as (
         , extract(week from date_day) as week_number
         , format_datetime('%b', date_day) as month_name
         , format_datetime('%a', date_day) as day_of_week_name
-    from date_spine
+    from 
+        date_spine
 )
 
 , dim_date as (
@@ -25,6 +26,7 @@ with date_spine as (
         date_id
         , date_day
         , day_of_week_name
+        , year_number
         , quarter_number
         , concat("Q", quarter_number, ' ', year_number) as quarter_desc
         , month_number
@@ -32,7 +34,23 @@ with date_spine as (
         , concat("M", lpad(cast(month_number as string), 2, '0'), ' ', year_number) as month_desc
         , week_number
         , concat("Wk ", lpad(cast(week_number as string), 2, '0'), ' ', year_number) as week_desc
-    from date_periods
+    from 
+        date_periods
 )
 
-select * from dim_date
+select 
+    /* Primary Key */
+    dim_date.date_id as id
+    /* Properties */
+    ,dim_date.date_day
+    ,dim_date.day_of_week_name
+    ,dim_date.year_number
+    ,dim_date.quarter_number
+    ,dim_date.quarter_desc
+    ,dim_date.month_number
+    ,dim_date.month_name
+    ,dim_date.month_desc
+    ,dim_date.week_number
+    ,dim_date.week_desc
+from 
+    dim_date


### PR DESCRIPTION
## Review goals
* Test that `dbt docs generate` & `dbt docs serve` produce expected results
* Merge branch into main after approved @gavh3 

## Overview
* Added documentation for `analytics/intermediate` models
* Added documentation for the new tables in `staging` models, `linescore` and `game`... also changed from `boxscore_game` to `boxscore`
* Added documentation for d_date, reformatted query a little
*  Changed a column name in d_division and all of its dependencies
* Tested run in prod and dev + docs and ran as expected

## Future considerations
* the `linescore` table in `staging` seems to have game_id duplicated (`id` and `game_id`) - is this necessary?